### PR TITLE
fix: allow counter_offer type in interaction endpoint

### DIFF
--- a/src/api/routes/athletes.ts
+++ b/src/api/routes/athletes.ts
@@ -538,7 +538,7 @@ athletes.post('/:id/interactions', requireAuth('athlete', 'manager', 'collaborat
     return c.json({ error: 'type and content are required' }, 400)
   }
 
-  const validTypes = ['email', 'call', 'note']
+  const validTypes: string[] = ['email', 'call', 'note', 'counter_offer', 'status_change', 'agreement']
   if (!validTypes.includes(type)) {
     return c.json({ error: `type must be one of: ${validTypes.join(', ')}` }, 400)
   }


### PR DESCRIPTION
Fix bug #16: when an athlete submitted a counter-offer, the backend rejected it with "type must be one of: email, call, note".

The validation list was missing `counter_offer`, `status_change`, and `agreement` — all valid types defined in the shared type definition.

Generated with [Claude Code](https://claude.ai/code)