### PR TITLE
feat: bloquer la sélection aux épreuves quand participation confirmée

### DIFF
--- a/src/api/routes/applications.ts
+++ b/src/api/routes/applications.ts
@@ -186,6 +186,17 @@ applications.patch('/:id/participation-status', async (c) => {
   const app = apps[0]
   const currentStatus = app.participationStatus as ParticipationStatus
 
+  // Block changes when athlete negotiation is confirmed
+  const athletes = await db
+    .select({ negotiationStatus: schema.athlete.negotiationStatus })
+    .from(schema.athlete)
+    .where(eq(schema.athlete.id, app.athleteId))
+    .limit(1)
+
+  if (athletes.length > 0 && athletes[0].negotiationStatus === 'confirmed') {
+    return c.json({ error: 'Cannot change participation status when athlete negotiation is confirmed' }, 403)
+  }
+
   // Validate transition
   const allowed = PARTICIPATION_TRANSITIONS[currentStatus]
   if (!allowed || !allowed.includes(newStatus)) {

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -215,7 +215,8 @@
   "participation": {
     "pending": "Pending",
     "selected": "Selected",
-    "not_selected": "Not selected"
+    "not_selected": "Not selected",
+    "lockedConfirmed": "Selection locked — participation confirmed"
   },
   "selection": {
     "title": "Candidate Selection",

--- a/src/shared/i18n/fr.json
+++ b/src/shared/i18n/fr.json
@@ -215,7 +215,8 @@
   "participation": {
     "pending": "En attente",
     "selected": "Sélectionné",
-    "not_selected": "Non sélectionné"
+    "not_selected": "Non sélectionné",
+    "lockedConfirmed": "Sélection verrouillée — participation confirmée"
   },
   "selection": {
     "title": "Sélection des candidats",

--- a/src/web/pages/collaborator/AthletePage.tsx
+++ b/src/web/pages/collaborator/AthletePage.tsx
@@ -562,9 +562,9 @@ function BannerEventRow({ app, athlete, edition, isStaff, onParticipationChange,
         </div>
       )}
 
-      {/* Participation status — staff gets buttons, athlete/manager gets read-only badge */}
-      <div className="flex gap-1 shrink-0">
-        {isStaff ? (
+      {/* Participation status — staff gets buttons (locked when athlete is confirmed), others get read-only badge */}
+      <div className="flex gap-1 shrink-0 items-center">
+        {isStaff && athlete.negotiationStatus !== 'confirmed' ? (
           <>
             {(['pending', 'selected', 'not_selected'] as const).map((status) => (
               <button
@@ -586,9 +586,14 @@ function BannerEventRow({ app, athlete, edition, isStaff, onParticipationChange,
             ))}
           </>
         ) : (
-          <span className={`text-[10px] px-2 py-0.5 rounded font-medium ${PARTICIPATION_COLORS[app.participationStatus] ?? 'bg-gray-100 text-gray-500'}`}>
-            {t(`participation.${app.participationStatus}`)}
-          </span>
+          <>
+            <span className={`text-[10px] px-2 py-0.5 rounded font-medium ${PARTICIPATION_COLORS[app.participationStatus] ?? 'bg-gray-100 text-gray-500'}`}>
+              {t(`participation.${app.participationStatus}`)}
+            </span>
+            {isStaff && athlete.negotiationStatus === 'confirmed' && (
+              <span className="text-[10px] text-gray-400" title={t('participation.lockedConfirmed')}>🔒</span>
+            )}
+          </>
         )}
       </div>
 


### PR DESCRIPTION
Ferme #18

Empêche la modification des statuts de sélection aux épreuves (pending/selected/not_selected) lorsque la participation de l'athlète est dans le statut Confirmé.

**Changements :**
- Frontend : dans le bandeau (`BannerEventRow`), affichage en lecture seule + icône 🔒 quand statut = confirmed
- Backend : `PATCH /applications/:id/participation-status` retourne 403 si l'athlète est confirmed

Generated with [Claude Code](https://claude.ai/code)