### PR TITLE
feat: Afficher l'aperçu du mail après inscription (#23)

### DIFF
--- a/src/api/routes/athletes.ts
+++ b/src/api/routes/athletes.ts
@@ -6,6 +6,7 @@ import { athleteRegistrationSchema, batchAthleteRegistrationSchema, athleteUpdat
 import { NEGOTIATION_TRANSITIONS, COMMITTEE_EXTRA_TRANSITIONS, ATHLETE_TRANSITIONS } from '@shared/constants'
 import { requireAuth } from '../middleware/auth'
 import { sendEmail, sendMagicLinkEmail, sendStatusChangeEmail } from '../services/email'
+import type { EmailContent } from '../services/email'
 import { generateToken, magicLinkExpiresAt } from '../services/auth'
 import type { Env } from '../index'
 import type { NegotiationStatus } from '@shared/types'
@@ -87,6 +88,7 @@ athletes.post('/', zValidator('json', athleteRegistrationSchema), async (c) => {
 
   // If email provided, create a user record so the athlete can log in later
   let magicLinkSent = false
+  let emailPreview: EmailContent | null = null
   if (data.athleteEmail) {
     const existingUsers = await db
       .select()
@@ -124,7 +126,7 @@ athletes.post('/', zValidator('json', athleteRegistrationSchema), async (c) => {
     })
 
     const baseUrl = c.req.header('Origin') ?? 'http://localhost:5173'
-    await sendMagicLinkEmail(db, data.athleteEmail, token, baseUrl)
+    emailPreview = await sendMagicLinkEmail(db, data.athleteEmail, token, baseUrl)
     magicLinkSent = true
   }
 
@@ -150,6 +152,7 @@ athletes.post('/', zValidator('json', athleteRegistrationSchema), async (c) => {
     athleteId,
     applicationIds,
     magicLinkSent,
+    emailPreview,
   }, 201)
 })
 

--- a/src/api/services/email.ts
+++ b/src/api/services/email.ts
@@ -42,7 +42,13 @@ export async function sendEmail({ db, to, subject, body, htmlBody, lang = 'en', 
   return emailId
 }
 
-export async function sendMagicLinkEmail(db: DB, email: string, token: string, baseUrl: string, lang: 'en' | 'fr' = 'en'): Promise<void> {
+export interface EmailContent {
+  subject: string
+  body: string
+  htmlBody: string
+}
+
+export async function sendMagicLinkEmail(db: DB, email: string, token: string, baseUrl: string, lang: 'en' | 'fr' = 'en'): Promise<EmailContent> {
   const link = `${baseUrl}/auth/verify?token=${token}`
   const subject = lang === 'fr' ? 'Votre lien de connexion — Atletica Genève' : 'Your login link — Atletica Geneve'
   const body = lang === 'fr'
@@ -54,6 +60,7 @@ export async function sendMagicLinkEmail(db: DB, email: string, token: string, b
     : `<p>Hello,</p><p>Click the following link to log in:</p><p><a href="${link}">${link}</a></p><p>This link is single-use and expires in 30 minutes.</p><p>Atletica Geneve</p>`
 
   await sendEmail({ db, to: email, subject, body, htmlBody, lang })
+  return { subject, body, htmlBody }
 }
 
 export async function sendStatusChangeEmail(

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -357,6 +357,11 @@
     "hotelName": "Hotel name",
     "noHotelsYet": "No hotels yet"
   },
+  "emailPreview": {
+    "title": "Email preview",
+    "description": "Here is the content of the email that would have been sent to the athlete if the mail sending engine were active.",
+    "subject": "Subject"
+  },
   "action": {
     "acceptOffer": "Accept offer",
     "counterOffer": "Counter-offer",

--- a/src/shared/i18n/fr.json
+++ b/src/shared/i18n/fr.json
@@ -357,6 +357,11 @@
     "hotelName": "Nom de l'hôtel",
     "noHotelsYet": "Aucun hôtel pour l'instant"
   },
+  "emailPreview": {
+    "title": "Aperçu du mail envoyé",
+    "description": "Voici le contenu du mail qui aurait été envoyé à l'athlète si le moteur d'envoi de mails était actif.",
+    "subject": "Sujet"
+  },
   "action": {
     "acceptOffer": "Accepter l'offre",
     "counterOffer": "Faire une contre-offre",

--- a/src/web/pages/athlete/RegisterPage.tsx
+++ b/src/web/pages/athlete/RegisterPage.tsx
@@ -23,6 +23,7 @@ export default function AthleteRegisterPage() {
   const [submitted, setSubmitted] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
+  const [emailPreview, setEmailPreview] = useState<{ subject: string; body: string } | null>(null)
 
   // Form state
   const [form, setForm] = useState({
@@ -81,7 +82,7 @@ export default function AthleteRegisterPage() {
     setSubmitting(true)
     setError('')
     try {
-      await api.post('/api/v1/athletes', {
+      const result = await api.post('/api/v1/athletes', {
         firstName: form.firstName,
         lastName: form.lastName,
         gender: form.gender,
@@ -100,13 +101,45 @@ export default function AthleteRegisterPage() {
         dopingFree: form.dopingFree,
         participantNotes: form.participantNotes || undefined,
         additionalNotes: form.additionalNotes || undefined,
-      })
-      setSubmitted(true)
+      }) as { emailPreview?: { subject: string; body: string } | null }
+      if (result.emailPreview) {
+        setEmailPreview(result.emailPreview)
+      } else {
+        setSubmitted(true)
+      }
     } catch (err) {
       setError(err instanceof ApiError ? err.message : t('common.error'))
     } finally {
       setSubmitting(false)
     }
+  }
+
+  if (emailPreview) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <div className="w-full max-w-lg">
+          <h1 className="text-xl font-bold mb-4 text-center">Atletica Genève</h1>
+          <div className="bg-white rounded-lg border p-6">
+            <h2 className="font-bold text-sm mb-1">{t('emailPreview.title')}</h2>
+            <p className="text-xs text-gray-500 mb-4">{t('emailPreview.description')}</p>
+            <div className="bg-gray-50 rounded border p-4 text-xs space-y-3 mb-6">
+              <div>
+                <span className="font-semibold text-gray-600">{t('emailPreview.subject')} :</span>{' '}
+                <span>{emailPreview.subject}</span>
+              </div>
+              <hr />
+              <pre className="whitespace-pre-wrap font-sans leading-relaxed">{emailPreview.body}</pre>
+            </div>
+            <button
+              onClick={() => { setEmailPreview(null); setSubmitted(true) }}
+              className="w-full px-4 py-2 text-sm bg-gray-900 text-white rounded-md hover:bg-gray-800"
+            >
+              {t('common.close')}
+            </button>
+          </div>
+        </div>
+      </div>
+    )
   }
 
   if (submitted) {


### PR DESCRIPTION
Ferme #23.

## Résumé

- email.ts : `sendMagicLinkEmail` retourne maintenant le contenu de l'email (subject, body, htmlBody)
- athletes.ts : `emailPreview` inclus dans la réponse API POST /athletes
- RegisterPage.tsx : page intermédiaire affichant le contenu du mail après soumission, avec bouton Fermer
- i18n fr/en : ajout des clés emailPreview

Generated with [Claude Code](https://claude.ai/code)