### PR TITLE
feat: Mise en oeuvre de la révision des statuts dans la page athlète (#27)

### DIFF
--- a/src/api/routes/agreements.ts
+++ b/src/api/routes/agreements.ts
@@ -1,9 +1,9 @@
 import { Hono } from 'hono'
-import { eq, desc, and } from 'drizzle-orm'
+import { eq, desc } from 'drizzle-orm'
 import * as schema from '../db/schema'
 import { agreementSchema } from '@shared/validation'
 import { requireAuth } from '../middleware/auth'
-import { sendEmail } from '../services/email'
+import { sendEmail, buildTransitionEmail } from '../services/email'
 import type { Env } from '../index'
 import type { NegotiationStatus, ParticipationStatus } from '@shared/types'
 
@@ -109,6 +109,13 @@ agreements.post('/:athleteId/agreements', async (c) => {
     }, 400)
   }
 
+  const hasSelected = apps.some(a => (a.participationStatus as ParticipationStatus) === 'selected')
+  if (!hasSelected) {
+    return c.json({
+      error: 'At least one application must be selected before sending an agreement',
+    }, 400)
+  }
+
   // Get edition costs
   const editions = await db.select().from(schema.edition).limit(1)
   if (editions.length === 0) {
@@ -197,41 +204,40 @@ agreements.post('/:athleteId/agreements', async (c) => {
     authorName: `${user.firstName} ${user.lastName}`,
   })
 
-  // Send email notification to athlete and manager about the agreement
+  // Build transition email for agreement_sent
   const athleteName = `${ath.firstName} ${ath.lastName}`
-  const nightCount = [
-    data.hotelNightTue, data.hotelNightWed, data.hotelNightThu,
-    data.hotelNightFri, data.hotelNightSat, data.hotelNightSun,
-  ].filter(Boolean).length
+  const meetingName = edition.name
+  const senderName = `${user.firstName} ${user.lastName}`
+  const organizationName = 'Atletica Geneve'
 
-  const agreementSummary = [
-    `Appearance fee: CHF ${data.appearanceFee}`,
-    `Transport: CHF ${data.transport}`,
-    `Hotel nights: ${nightCount}`,
-    `Total cost: CHF ${totalCost}`,
-    data.notes ? `Notes: ${data.notes}` : null,
-  ].filter(Boolean).join('\n')
-
-  const agreementBody = `An agreement offer (v${nextVersion}) has been sent for ${athleteName}.\n\n${agreementSummary}\n\nPlease log in to the portal to review and respond.`
-
-  if (ath.athleteEmail) {
-    await sendEmail({
-      db,
-      to: ath.athleteEmail,
-      subject: `Agreement offer — ${athleteName}`,
-      body: agreementBody,
-      relatedAthleteId: athleteId,
-    })
-  }
-
+  let recipientName = athleteName
+  let managerEmail: string | null = null
   if (ath.managerId) {
     const managerRows = await db.select().from(schema.user).where(eq(schema.user.id, ath.managerId)).limit(1)
-    if (managerRows.length > 0 && managerRows[0].email) {
+    if (managerRows.length > 0) {
+      recipientName = `${managerRows[0].firstName} ${managerRows[0].lastName}`
+      managerEmail = managerRows[0].email ?? null
+    }
+  }
+
+  const transitionEmail = buildTransitionEmail({
+    from: currentStatus as NegotiationStatus,
+    to: 'agreement_sent',
+    athleteName,
+    meetingName,
+    senderName,
+    recipientName,
+    organizationName,
+  })
+
+  if (transitionEmail) {
+    const targetEmail = ath.athleteEmail ?? managerEmail
+    if (targetEmail) {
       await sendEmail({
         db,
-        to: managerRows[0].email,
-        subject: `Agreement offer — ${athleteName}`,
-        body: agreementBody,
+        to: targetEmail,
+        subject: transitionEmail.subject,
+        body: transitionEmail.body,
         relatedAthleteId: athleteId,
       })
     }
@@ -243,6 +249,7 @@ agreements.post('/:athleteId/agreements', async (c) => {
     version: nextVersion,
     totalCost,
     direction: 'to_athlete',
+    emailPreview: transitionEmail ?? undefined,
   }, 201)
 })
 

--- a/src/api/routes/athletes.ts
+++ b/src/api/routes/athletes.ts
@@ -5,7 +5,7 @@ import * as schema from '../db/schema'
 import { athleteRegistrationSchema, batchAthleteRegistrationSchema, athleteUpdateSchema, negotiationStatusChangeSchema } from '@shared/validation'
 import { NEGOTIATION_TRANSITIONS, COMMITTEE_EXTRA_TRANSITIONS, ATHLETE_TRANSITIONS } from '@shared/constants'
 import { requireAuth } from '../middleware/auth'
-import { sendEmail, sendMagicLinkEmail, sendStatusChangeEmail } from '../services/email'
+import { sendEmail, sendMagicLinkEmail, buildTransitionEmail } from '../services/email'
 import type { EmailContent } from '../services/email'
 import { generateToken, magicLinkExpiresAt } from '../services/auth'
 import type { Env } from '../index'
@@ -324,6 +324,7 @@ athletes.get('/:id', requireAuth('athlete', 'manager', 'collaborator', 'committe
     agreements,
     interactions,
     edition: edition ? {
+      name: edition.name,
       weightPB: edition.weightPB,
       weightSB: edition.weightSB,
       weightRanking: edition.weightRanking,
@@ -435,41 +436,58 @@ athletes.patch('/:id/negotiation-status', requireAuth('athlete', 'manager', 'col
     })
     .where(eq(schema.athlete.id, id))
 
-  // Send email notification to athlete and manager
+  // Send transition email
   const editions = await db.select().from(schema.edition).limit(1)
   const edition = editions[0]
-  const baseUrl = c.req.header('Origin') ?? 'http://localhost:5173'
-  const portalUrl = `${baseUrl}/portal`
+  const meetingName = edition?.name ?? 'Atletica Geneve'
+  const organizationName = 'Atletica Geneve'
+  const athleteName = `${ath.firstName} ${ath.lastName}`
+  const senderName = `${user.firstName} ${user.lastName}`
 
-  // Look up athlete's user record for preferred language
-  let athleteLang: 'en' | 'fr' = 'en'
-  if (ath.userId) {
-    const userRows = await db.select().from(schema.user).where(eq(schema.user.id, ath.userId)).limit(1)
-    if (userRows.length > 0) {
-      athleteLang = (userRows[0].preferredLang as 'en' | 'fr') ?? 'en'
-    }
-  }
-
-  let emailLogId: string | null = null
-  if (ath.athleteEmail) {
-    emailLogId = await sendStatusChangeEmail(db, ath.athleteEmail, `${ath.firstName} ${ath.lastName}`, newStatus, portalUrl, athleteLang, undefined, id)
-  }
-
+  // Look up manager once for both recipient name and email
+  let recipientName = athleteName
+  let managerEmail: string | null = null
   if (ath.managerId) {
     const managerRows = await db.select().from(schema.user).where(eq(schema.user.id, ath.managerId)).limit(1)
-    if (managerRows.length > 0 && managerRows[0].email) {
-      const managerLang = (managerRows[0].preferredLang as 'en' | 'fr') ?? 'en'
-      await sendStatusChangeEmail(db, managerRows[0].email, `${ath.firstName} ${ath.lastName}`, newStatus, portalUrl, managerLang, undefined, id)
+    if (managerRows.length > 0) {
+      recipientName = `${managerRows[0].firstName} ${managerRows[0].lastName}`
+      managerEmail = managerRows[0].email ?? null
     }
   }
 
-  // Notify edition notification email
-  if (edition?.notificationEmail) {
-    await sendEmail({
+  const transitionEmail = buildTransitionEmail({
+    from: currentStatus,
+    to: newStatus,
+    athleteName,
+    meetingName,
+    senderName,
+    recipientName,
+    organizationName,
+  })
+
+  let emailLogId: string | null = null
+
+  // Staff-initiated transitions: email goes to athlete/manager
+  if (isStaff && transitionEmail) {
+    const emailTo = ath.athleteEmail ?? managerEmail
+    if (emailTo) {
+      emailLogId = await sendEmail({
+        db,
+        to: emailTo,
+        subject: transitionEmail.subject,
+        body: transitionEmail.body,
+        relatedAthleteId: id,
+      })
+    }
+  }
+
+  // Athlete/manager-initiated transitions: notify edition notification email
+  if (!isStaff && edition?.notificationEmail && transitionEmail) {
+    emailLogId = await sendEmail({
       db,
       to: edition.notificationEmail,
-      subject: `Status change — ${ath.firstName} ${ath.lastName}`,
-      body: `${ath.firstName} ${ath.lastName} status changed from "${currentStatus}" to "${newStatus}" by ${user.firstName} ${user.lastName}.`,
+      subject: transitionEmail.subject,
+      body: transitionEmail.body,
       relatedAthleteId: id,
     })
   }
@@ -480,11 +498,16 @@ athletes.patch('/:id/negotiation-status', requireAuth('athlete', 'manager', 'col
     type: 'status_change',
     content: `Negotiation status changed from "${currentStatus}" to "${newStatus}"`,
     authorId: user.id,
-    authorName: `${user.firstName} ${user.lastName}`,
+    authorName: senderName,
     emailLogId,
   })
 
-  return c.json({ id, status: newStatus, previousStatus: currentStatus })
+  return c.json({
+    id,
+    status: newStatus,
+    previousStatus: currentStatus,
+    emailPreview: transitionEmail ?? undefined,
+  })
 })
 
 // ── DELETE /athletes/:id — archive (committee only) ──────────────────────────

--- a/src/api/services/email.ts
+++ b/src/api/services/email.ts
@@ -5,6 +5,7 @@
 
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import * as schema from '../db/schema'
+import type { NegotiationStatus } from '@shared/types'
 
 type DB = DrizzleD1Database<typeof schema>
 
@@ -61,6 +62,94 @@ export async function sendMagicLinkEmail(db: DB, email: string, token: string, b
 
   await sendEmail({ db, to: email, subject, body, htmlBody, lang })
   return { subject, body, htmlBody }
+}
+
+export interface TransitionEmail {
+  subject: string
+  body: string
+}
+
+export function buildTransitionEmail(params: {
+  from: NegotiationStatus
+  to: NegotiationStatus
+  athleteName: string
+  meetingName: string
+  senderName: string
+  recipientName: string
+  organizationName: string
+}): TransitionEmail | null {
+  const { from, to, athleteName, meetingName, senderName, recipientName, organizationName } = params
+  const key = `${from}__${to}`
+
+  switch (key) {
+    case 'to_review__agreement_sent':
+      return {
+        subject: `${meetingName} — Participation Agreement`,
+        body: `Dear ${recipientName},\n\nWe are pleased to inform you that we have reviewed ${athleteName}'s application for ${meetingName} and are ready to move forward with a participation offer.\n\nPlease find attached the participation agreement for your review. We would be grateful if you could let us know your decision at your earliest convenience.\n\nShould you have any questions or wish to discuss any aspect of the agreement, please do not hesitate to reach out.\n\nWe look forward to hearing from you.\n\nKind regards,\n${senderName} — ${organizationName}`,
+      }
+    case 'to_review__rejected':
+      return {
+        subject: `${meetingName} — Application Update`,
+        body: `Dear ${recipientName},\n\nThank you for ${athleteName}'s interest in participating in ${meetingName}.\n\nAfter careful review, we regret to inform you that we are unable to offer a place at this edition of the meeting.\n\nWe sincerely appreciate your trust and hope to have the opportunity to welcome ${athleteName} at a future event.\n\nKind regards,\n${senderName} — ${organizationName}`,
+      }
+    case 'to_review__withdrawn':
+      return {
+        subject: `${meetingName} — Withdrawal of Application`,
+        body: `Dear ${recipientName},\n\nI am writing to inform you that ${athleteName} is withdrawing their application for ${meetingName}.\n\nWe are sorry for any inconvenience this may cause and thank you for your understanding. We hope to have the opportunity to work together at a future event.\n\nKind regards,\n${senderName}`,
+      }
+    case 'agreement_sent__confirmed':
+      return {
+        subject: `${meetingName} — Agreement Accepted`,
+        body: `Dear ${recipientName},\n\nWe are delighted to confirm ${athleteName}'s participation in ${meetingName} on the terms set out in the agreement.\n\nWe look forward to the event and thank you for the opportunity.\n\nKind regards,\n${senderName}`,
+      }
+    case 'agreement_sent__counter_offer_sent':
+      return {
+        subject: `${meetingName} — Counter-offer`,
+        body: `Dear ${recipientName},\n\nThank you for sending the participation agreement for ${athleteName} at ${meetingName}.\n\nHaving reviewed the proposed terms, we would like to suggest some adjustments. Please find our counter-offer attached.\n\nWe remain open to discussion and look forward to reaching a mutually satisfactory agreement.\n\nKind regards,\n${senderName}`,
+      }
+    case 'agreement_sent__withdrawn':
+      return {
+        subject: `${meetingName} — Withdrawal`,
+        body: `Dear ${recipientName},\n\nAfter careful consideration, we regret to inform you that ${athleteName} must withdraw from ${meetingName}.\n\nWe are sorry for any inconvenience this may cause and sincerely thank you for the opportunity that was extended. We hope to be able to collaborate at a future event.\n\nKind regards,\n${senderName}`,
+      }
+    case 'counter_offer_sent__agreement_sent':
+      return {
+        subject: `${meetingName} — Updated Participation Agreement`,
+        body: `Dear ${recipientName},\n\nThank you for your counter-offer regarding ${athleteName}'s participation in ${meetingName}. We have taken your points into consideration and are pleased to send you an updated participation agreement.\n\nWe hope this revised proposal meets your expectations. Please do not hesitate to contact us if you have any further questions.\n\nKind regards,\n${senderName} — ${organizationName}`,
+      }
+    case 'counter_offer_sent__rejected':
+      return {
+        subject: `${meetingName} — End of Negotiations`,
+        body: `Dear ${recipientName},\n\nThank you for your counter-offer regarding ${athleteName}'s participation in ${meetingName}.\n\nAfter careful consideration, we regret to inform you that we are unable to reach an agreement for this edition of the meeting.\n\nWe sincerely value your interest and hope to have the opportunity to work together in the future.\n\nKind regards,\n${senderName} — ${organizationName}`,
+      }
+    case 'counter_offer_sent__withdrawn':
+      return {
+        subject: `${meetingName} — Withdrawal`,
+        body: `Dear ${recipientName},\n\nFurther to our counter-offer, we have decided to withdraw ${athleteName}'s candidacy for ${meetingName}.\n\nWe thank you for the time and effort devoted to the negotiation and apologize for any inconvenience caused. We hope to have the pleasure of working together at a future event.\n\nKind regards,\n${senderName}`,
+      }
+    case 'confirmed__withdrawn':
+      return {
+        subject: `${meetingName} — Withdrawal of Confirmed Participation`,
+        body: `Dear ${recipientName},\n\nWe regret to inform you that ${athleteName} is unfortunately forced to withdraw from ${meetingName}, despite having previously confirmed their participation.\n\nWe sincerely apologize for the disruption this may cause to your event organization and thank you for your understanding. Please do not hesitate to contact us if you need any further information.\n\nKind regards,\n${senderName}`,
+      }
+    case 'confirmed__rejected':
+      return {
+        subject: `${meetingName} — Update Regarding ${athleteName}'s Participation`,
+        body: `Dear ${recipientName},\n\nWe regret to inform you that, due to exceptional circumstances, ${athleteName}'s confirmed participation in ${meetingName} has had to be cancelled.\n\nWe are truly sorry for the inconvenience this causes and want to assure you that this decision was not taken lightly. We remain available to discuss this matter and hope to have the opportunity to welcome ${athleteName} at a future event.\n\nKind regards,\n${senderName} — ${organizationName}`,
+      }
+    case 'rejected__to_review':
+      return {
+        subject: `${meetingName} — Application Reopened`,
+        body: `Dear ${recipientName},\n\nFollowing our previous communication, we are pleased to inform you that ${athleteName}'s application for ${meetingName} has been reopened.\n\nWe would like to invite you to resume discussions with us. Please feel free to contact us at your convenience.\n\nKind regards,\n${senderName} — ${organizationName}`,
+      }
+    case 'withdrawn__to_review':
+      return {
+        subject: `${meetingName} — Invitation to Reconsider`,
+        body: `Dear ${recipientName},\n\nFollowing ${athleteName}'s withdrawal from ${meetingName}, we would like to reach out and explore whether there might be an opportunity to resume the process.\n\nIf circumstances have changed and you would be open to reconsidering, we would be very pleased to discuss this with you. Please feel free to contact us.\n\nKind regards,\n${senderName} — ${organizationName}`,
+      }
+    default:
+      return null
+  }
 }
 
 export async function sendStatusChangeEmail(

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,10 +1,13 @@
 import type { NegotiationStatus, ParticipationStatus } from './types'
 
+// Staff (collaborator/committee) allowed direct status transitions.
+// Note: agreement_sent is only reached via agreement creation (POST /agreements), never via direct PATCH.
+// During agreement_sent, the ball is in the athlete/manager's court — staff cannot act.
 export const NEGOTIATION_TRANSITIONS: Record<NegotiationStatus, NegotiationStatus[]> = {
-  to_review:           ['agreement_sent', 'rejected'],
-  agreement_sent:      ['confirmed', 'rejected', 'counter_offer_sent', 'withdrawn'],
-  counter_offer_sent:  ['agreement_sent', 'rejected', 'withdrawn'],
-  confirmed:           ['withdrawn'],
+  to_review:           ['rejected'],
+  agreement_sent:      [],
+  counter_offer_sent:  ['rejected'],
+  confirmed:           [],
   rejected:            [],
   withdrawn:           [],
 }

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -74,7 +74,7 @@
     "agreement_sent": "Agreement sent",
     "counter_offer_sent": "Counter-offer sent",
     "confirmed": "Confirmed",
-    "rejected": "Not selected",
+    "rejected": "Rejected",
     "withdrawn": "Withdrawn",
     "contract_sent": "Offer sent",
     "counter_offer": "Counter-offer",
@@ -92,7 +92,22 @@
     "withdraw": "Are you sure you want to withdraw?",
     "withdrawAthlete": "Withdraw {{athlete}}?",
     "archiveAthlete": "Archive {{athlete}}? This will hide them from all lists.",
-    "deleteHotel": "Delete hotel \"{{hotel}}\" and all its room types?"
+    "deleteHotel": "Delete hotel \"{{hotel}}\" and all its room types?",
+    "transition": {
+      "to_review__agreement_sent": "You are about to send a participation agreement to **{{athlete}}**. They will be notified and invited to respond.",
+      "to_review__rejected": "You are about to reject **{{athlete}}**'s application for **{{meeting}}**. They will be notified of this decision.",
+      "to_review__withdrawn": "You are about to withdraw **{{athlete}}**'s application from **{{meeting}}**. The organizers will be notified.",
+      "agreement_sent__confirmed": "You are about to accept the participation agreement for **{{athlete}}** in **{{meeting}}**. This will confirm their participation.",
+      "agreement_sent__counter_offer_sent": "You are about to send a counter-offer regarding **{{athlete}}**'s participation in **{{meeting}}**. The organizers will be notified.",
+      "agreement_sent__withdrawn": "You are about to withdraw **{{athlete}}** from **{{meeting}}**, while a participation agreement is pending. The organizers will be notified.",
+      "counter_offer_sent__agreement_sent": "You are about to send an updated participation agreement to **{{athlete}}**, taking their counter-offer into account. They will be notified and invited to respond.",
+      "counter_offer_sent__rejected": "You are about to reject **{{athlete}}**'s counter-offer and end the negotiation for **{{meeting}}**. They will be notified.",
+      "counter_offer_sent__withdrawn": "You are about to withdraw **{{athlete}}**'s candidacy from **{{meeting}}**. The organizers will be notified.",
+      "confirmed__withdrawn": "You are about to withdraw **{{athlete}}** from **{{meeting}}**, despite their participation having been confirmed. The organizers will be notified.",
+      "confirmed__rejected": "You are about to cancel **{{athlete}}**'s confirmed participation in **{{meeting}}**. This is a committee override action. They will be notified.",
+      "rejected__to_review": "You are about to reopen **{{athlete}}**'s application for **{{meeting}}**. This will restart the negotiation process. They will be notified.",
+      "withdrawn__to_review": "You are about to reopen **{{athlete}}**'s application for **{{meeting}}** following their withdrawal. This will restart the negotiation process. They will be notified."
+    }
   },
   "signup": {
     "title": "Welcome to Atletica Geneve",
@@ -368,6 +383,13 @@
     "counterOfferPlaceholder": "Describe your counter-proposal…",
     "withdraw": "Withdraw",
     "sendMessage": "Send message",
-    "messagePlaceholder": "Type your message…"
+    "messagePlaceholder": "Type your message…",
+    "sendAgreement": "Send Agreement",
+    "accept": "Accept",
+    "sendCounterOffer": "Send Counter-offer",
+    "reject": "Reject",
+    "overrideReject": "Override: Reject",
+    "reopen": "Reopen",
+    "awaitingResponse": "Awaiting athlete / manager response"
   }
 }

--- a/src/shared/i18n/fr.json
+++ b/src/shared/i18n/fr.json
@@ -70,14 +70,14 @@
     "candidates": "Candidats"
   },
   "status": {
-    "to_review": "En cours d'examen",
+    "to_review": "À examiner",
     "agreement_sent": "Accord envoyé",
-    "counter_offer_sent": "Contre-proposition envoyée",
+    "counter_offer_sent": "Contre-offre envoyée",
     "confirmed": "Confirmé",
-    "rejected": "Non retenu",
+    "rejected": "Rejeté",
     "withdrawn": "Retiré",
     "contract_sent": "Offre envoyée",
-    "counter_offer": "Contre-proposition",
+    "counter_offer": "Contre-offre",
     "accepted": "Confirmé",
     "rattraper": "Rattraper"
   },
@@ -92,7 +92,22 @@
     "withdraw": "Voulez-vous vraiment vous retirer ?",
     "withdrawAthlete": "Retirer {{athlete}} ?",
     "archiveAthlete": "Archiver {{athlete}} ? Cela le masquera de toutes les listes.",
-    "deleteHotel": "Supprimer l'hôtel « {{hotel}} » et tous ses types de chambres ?"
+    "deleteHotel": "Supprimer l'hôtel « {{hotel}} » et tous ses types de chambres ?",
+    "transition": {
+      "to_review__agreement_sent": "Vous êtes sur le point d'envoyer un accord de participation à **{{athlete}}**. Il/elle sera notifié(e) et invité(e) à répondre.",
+      "to_review__rejected": "Vous êtes sur le point de rejeter la candidature de **{{athlete}}** pour **{{meeting}}**. Il/elle sera notifié(e) de cette décision.",
+      "to_review__withdrawn": "Vous êtes sur le point de retirer la candidature de **{{athlete}}** du **{{meeting}}**. Les organisateurs seront notifiés.",
+      "agreement_sent__confirmed": "Vous êtes sur le point d'accepter l'accord de participation de **{{athlete}}** pour **{{meeting}}**. Cela confirmera leur participation.",
+      "agreement_sent__counter_offer_sent": "Vous êtes sur le point d'envoyer une contre-offre concernant la participation de **{{athlete}}** à **{{meeting}}**. Les organisateurs seront notifiés.",
+      "agreement_sent__withdrawn": "Vous êtes sur le point de retirer **{{athlete}}** du **{{meeting}}**, alors qu'un accord de participation est en cours. Les organisateurs seront notifiés.",
+      "counter_offer_sent__agreement_sent": "Vous êtes sur le point d'envoyer un accord de participation mis à jour à **{{athlete}}**, tenant compte de sa contre-offre. Il/elle sera notifié(e) et invité(e) à répondre.",
+      "counter_offer_sent__rejected": "Vous êtes sur le point de rejeter la contre-offre de **{{athlete}}** et de mettre fin à la négociation pour **{{meeting}}**. Il/elle sera notifié(e).",
+      "counter_offer_sent__withdrawn": "Vous êtes sur le point de retirer la candidature de **{{athlete}}** du **{{meeting}}**. Les organisateurs seront notifiés.",
+      "confirmed__withdrawn": "Vous êtes sur le point de retirer **{{athlete}}** du **{{meeting}}**, alors que sa participation avait été confirmée. Les organisateurs seront notifiés.",
+      "confirmed__rejected": "Vous êtes sur le point d'annuler la participation confirmée de **{{athlete}}** à **{{meeting}}**. Il s'agit d'une action de substitution du comité. Il/elle sera notifié(e).",
+      "rejected__to_review": "Vous êtes sur le point de rouvrir la candidature de **{{athlete}}** pour **{{meeting}}**. Cela relancera le processus de négociation. Il/elle sera notifié(e).",
+      "withdrawn__to_review": "Vous êtes sur le point de rouvrir la candidature de **{{athlete}}** pour **{{meeting}}** suite à son retrait. Cela relancera le processus de négociation. Il/elle sera notifié(e)."
+    }
   },
   "signup": {
     "title": "Bienvenue à Atletica Genève",
@@ -365,9 +380,16 @@
   "action": {
     "acceptOffer": "Accepter l'offre",
     "counterOffer": "Faire une contre-offre",
-    "counterOfferPlaceholder": "Décrivez votre contre-proposition…",
+    "counterOfferPlaceholder": "Décrivez votre contre-offre…",
     "withdraw": "Se retirer",
     "sendMessage": "Envoyer un message",
-    "messagePlaceholder": "Tapez votre message…"
+    "messagePlaceholder": "Tapez votre message…",
+    "sendAgreement": "Envoyer l'accord",
+    "accept": "Accepter",
+    "sendCounterOffer": "Envoyer une contre-offre",
+    "reject": "Rejeter",
+    "overrideReject": "Annuler : Rejeter",
+    "reopen": "Rouvrir",
+    "awaitingResponse": "En attente de réponse de l'athlète / manager"
   }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -309,6 +309,7 @@ export interface ApplicationForAthlete extends Application {
 }
 
 export interface EditionCosts {
+  name: string
   weightPB: number
   weightSB: number
   weightRanking: number

--- a/src/web/pages/collaborator/AthletePage.tsx
+++ b/src/web/pages/collaborator/AthletePage.tsx
@@ -662,7 +662,12 @@ export default function AthletePage() {
   const [activeTab, setActiveTab] = useState<'personal' | 'negotiation'>('personal')
   const [openSection, setOpenSection] = useState<string | null>('identity')
   const [editingSection, setEditingSection] = useState<string | null>(null)
-  const [confirmAction, setConfirmAction] = useState<NegotiationStatus | null>(null)
+  const [confirmDialog, setConfirmDialog] = useState<{
+    fromStatus: NegotiationStatus
+    toStatus: NegotiationStatus
+    onConfirm: () => void
+  } | null>(null)
+  const [emailPreview, setEmailPreview] = useState<{ subject: string; body: string } | null>(null)
   const [showAgreementForm, setShowAgreementForm] = useState(false)
   const [noteType, setNoteType] = useState<'note' | 'call' | 'email'>('note')
   const [noteContent, setNoteContent] = useState('')
@@ -718,7 +723,11 @@ export default function AthletePage() {
   const statusMutation = useMutation({
     mutationFn: (status: NegotiationStatus) =>
       api.patch(`/api/v1/athletes/${id}/negotiation-status`, { status }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['athlete', id] }),
+    onSuccess: (data: { emailPreview?: { subject: string; body: string } }) => {
+      queryClient.invalidateQueries({ queryKey: ['athlete', id] })
+      setConfirmDialog(null)
+      if (data?.emailPreview) setEmailPreview(data.emailPreview)
+    },
   })
 
   const agreementMutation = useMutation({
@@ -727,9 +736,11 @@ export default function AthletePage() {
         ...data,
         hotelRoomId: data.hotelRoomId || undefined,
       }),
-    onSuccess: () => {
+    onSuccess: (data: { emailPreview?: { subject: string; body: string } }) => {
       queryClient.invalidateQueries({ queryKey: ['athlete', id] })
       setShowAgreementForm(false)
+      setConfirmDialog(null)
+      if (data?.emailPreview) setEmailPreview(data.emailPreview)
     },
   })
 
@@ -774,12 +785,13 @@ export default function AthletePage() {
   const counterOfferMutation = useMutation({
     mutationFn: async (text: string) => {
       await api.post(`/api/v1/athletes/${id}/interactions`, { type: 'counter_offer', content: text })
-      await api.patch(`/api/v1/athletes/${id}/negotiation-status`, { status: 'counter_offer_sent' })
+      return api.patch(`/api/v1/athletes/${id}/negotiation-status`, { status: 'counter_offer_sent' })
     },
-    onSuccess: () => {
+    onSuccess: (data: { emailPreview?: { subject: string; body: string } }) => {
       queryClient.invalidateQueries({ queryKey: ['athlete', id] })
       setShowCounterOfferModal(false)
       setCounterOfferText('')
+      if (data?.emailPreview) setEmailPreview(data.emailPreview)
     },
   })
 
@@ -829,6 +841,8 @@ export default function AthletePage() {
 
   const allDecided = athlete.applications.length > 0
     && athlete.applications.every(a => a.participationStatus !== 'pending')
+  const hasAtLeastOneSelected = athlete.applications.some(a => a.participationStatus === 'selected')
+  const canSendAgreement = allDecided && hasAtLeastOneSelected
 
   const inputCls = 'w-full px-2 py-1.5 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-900'
   const labelCls = 'block text-xs font-medium text-gray-500 mb-1'
@@ -944,49 +958,72 @@ export default function AthletePage() {
 
             {/* Action buttons */}
             <div className="flex flex-wrap gap-2 justify-end shrink-0">
-              {allowedTransitions.map((status) => {
-                const needsConfirm = ['confirmed', 'rejected', 'withdrawn', 'to_review'].includes(status)
-                const committeeOnly = isCommitteeOnly(status as NegotiationStatus)
 
-                // Athlete/manager-specific labels
+              {/* Staff: Send Agreement button (to_review and counter_offer_sent) */}
+              {isStaff && (currentStatus === 'to_review' || currentStatus === 'counter_offer_sent') && (
+                <button
+                  onClick={() => {
+                    setActiveTab('negotiation')
+                    setShowAgreementForm(true)
+                  }}
+                  disabled={!canSendAgreement}
+                  title={!canSendAgreement ? (allDecided ? t('selection.decideAllFirst') : t('selection.decideAllFirst')) : undefined}
+                  className={`text-xs px-3 py-1.5 rounded font-medium border ${
+                    canSendAgreement
+                      ? 'bg-blue-600 text-white border-blue-600 hover:bg-blue-700'
+                      : 'bg-gray-100 text-gray-300 border-gray-200 cursor-not-allowed'
+                  }`}
+                >
+                  {t('action.sendAgreement')}
+                </button>
+              )}
+
+              {/* Staff: awaiting athlete/manager response during agreement_sent */}
+              {isStaff && currentStatus === 'agreement_sent' && (
+                <span className="text-xs text-gray-500 italic py-1.5">{t('action.awaitingResponse')}</span>
+              )}
+
+              {/* All role-based direct status transitions */}
+              {allowedTransitions.map((toStatus) => {
+                const committeeOnly = isCommitteeOnly(toStatus as NegotiationStatus)
+
                 const buttonLabel = isAthleteOrManager
-                  ? status === 'confirmed' ? t('action.acceptOffer')
-                    : status === 'counter_offer_sent' ? t('action.counterOffer')
-                    : status === 'withdrawn' ? t('action.withdraw')
-                    : t(`status.${status}`)
-                  : committeeOnly && status === 'to_review'
-                    ? t('status.rattraper')
-                    : t(`status.${status}`)
+                  ? toStatus === 'confirmed' ? t('action.accept')
+                    : toStatus === 'counter_offer_sent' ? t('action.sendCounterOffer')
+                    : toStatus === 'withdrawn' ? t('action.withdraw')
+                    : t(`status.${toStatus}`)
+                  : committeeOnly && toStatus === 'rejected' ? t('action.overrideReject')
+                  : toStatus === 'to_review' ? t('action.reopen')
+                  : toStatus === 'rejected' ? t('action.reject')
+                  : t(`status.${toStatus}`)
 
                 return (
                   <button
-                    key={status}
+                    key={toStatus}
                     onClick={() => {
-                      if (isAthleteOrManager && status === 'counter_offer_sent') {
+                      if (isAthleteOrManager && toStatus === 'counter_offer_sent') {
                         setShowCounterOfferModal(true)
-                      } else if (status === 'agreement_sent' && isStaff) {
-                        setActiveTab('negotiation')
-                        setShowAgreementForm(true)
-                      } else if (needsConfirm) {
-                        setConfirmAction(status as NegotiationStatus)
                       } else {
-                        statusMutation.mutate(status as NegotiationStatus)
+                        setConfirmDialog({
+                          fromStatus: currentStatus,
+                          toStatus: toStatus as NegotiationStatus,
+                          onConfirm: () => statusMutation.mutate(toStatus as NegotiationStatus),
+                        })
                       }
                     }}
                     disabled={statusMutation.isPending}
-                    title={committeeOnly ? t('selection.rattraper') : undefined}
                     className={`text-xs px-3 py-1.5 rounded font-medium border ${
-                      status === 'confirmed'
+                      toStatus === 'confirmed'
                         ? 'bg-green-600 text-white border-green-600 hover:bg-green-700'
-                        : status === 'rejected'
+                        : toStatus === 'rejected' && committeeOnly
+                        ? 'bg-red-600 text-white border-red-600 hover:bg-red-700'
+                        : toStatus === 'rejected'
                         ? 'bg-red-50 text-red-600 border-red-200 hover:bg-red-100'
-                        : status === 'withdrawn'
+                        : toStatus === 'withdrawn'
                         ? 'bg-gray-50 text-gray-500 border-gray-200 hover:bg-gray-100'
-                        : status === 'agreement_sent'
-                        ? 'bg-blue-600 text-white border-blue-600 hover:bg-blue-700'
-                        : status === 'counter_offer_sent'
+                        : toStatus === 'counter_offer_sent'
                         ? 'bg-purple-600 text-white border-purple-600 hover:bg-purple-700'
-                        : status === 'to_review' && committeeOnly
+                        : toStatus === 'to_review' && committeeOnly
                         ? 'bg-orange-50 text-orange-600 border-orange-200 hover:bg-orange-100'
                         : 'bg-gray-100 text-gray-700 border-gray-200 hover:bg-gray-200'
                     }`}
@@ -1004,48 +1041,11 @@ export default function AthletePage() {
                 {t('action.sendMessage')}
               </button>
 
-              {allowedTransitions.length === 0 && !isAthleteOrManager && (
+              {allowedTransitions.length === 0 && !isAthleteOrManager && !(isStaff && currentStatus === 'agreement_sent') && (
                 <span className="text-xs text-gray-400 py-1.5">{t('selection.noActions')}</span>
               )}
             </div>
           </div>
-
-          {/* Confirm dialog */}
-          {confirmAction && (
-            <div className="mt-3 p-3 rounded border border-yellow-300 bg-yellow-50">
-              <p className="text-sm text-gray-900 mb-3">
-                {t('confirm.statusChange', {
-                  athlete: `${athlete.firstName} ${athlete.lastName}`,
-                  status: confirmAction === 'to_review' ? t('status.rattraper') : t(`status.${confirmAction}`),
-                })}
-              </p>
-              <div className="flex gap-2">
-                <button
-                  onClick={() => {
-                    statusMutation.mutate(confirmAction)
-                    setConfirmAction(null)
-                  }}
-                  className={`text-xs px-3 py-1.5 rounded font-medium ${
-                    confirmAction === 'confirmed'
-                      ? 'bg-green-600 text-white hover:bg-green-700'
-                      : confirmAction === 'rejected'
-                      ? 'bg-red-600 text-white hover:bg-red-700'
-                      : confirmAction === 'to_review'
-                      ? 'bg-orange-600 text-white hover:bg-orange-700'
-                      : 'bg-gray-600 text-white hover:bg-gray-700'
-                  }`}
-                >
-                  {t('common.confirm')}
-                </button>
-                <button
-                  onClick={() => setConfirmAction(null)}
-                  className="text-xs px-3 py-1.5 rounded border border-gray-300 hover:bg-gray-50"
-                >
-                  {t('common.cancel')}
-                </button>
-              </div>
-            </div>
-          )}
 
           {statusMutation.isError && (
             <p className="text-xs text-red-600 mt-2">{(statusMutation.error as Error)?.message || t('common.error')}</p>
@@ -1359,13 +1359,14 @@ export default function AthletePage() {
               <div className="bg-white rounded-lg border p-4">
                 <div className="flex items-center justify-between mb-3">
                   <h3 className="font-semibold text-sm">{t('contract.title')}</h3>
-                  {isStaff && !showAgreementForm && !['confirmed', 'rejected', 'withdrawn'].includes(currentStatus) && (
+                  {isStaff && !showAgreementForm && (currentStatus === 'to_review' || currentStatus === 'counter_offer_sent') && (
                     <button
                       onClick={() => setShowAgreementForm(true)}
-                      disabled={!allDecided}
-                      className={`text-xs ${allDecided ? 'text-blue-600 hover:text-blue-800' : 'text-gray-300 cursor-not-allowed'}`}
+                      disabled={!canSendAgreement}
+                      title={!canSendAgreement ? t('selection.decideAllFirst') : undefined}
+                      className={`text-xs ${canSendAgreement ? 'text-blue-600 hover:text-blue-800' : 'text-gray-300 cursor-not-allowed'}`}
                     >
-                      {latestAgreement ? t('contract.newVersion') : t('contract.sendOffer')}
+                      {latestAgreement ? t('contract.newVersion') : t('action.sendAgreement')}
                     </button>
                   )}
                 </div>
@@ -1503,11 +1504,17 @@ export default function AthletePage() {
 
                     <div className="flex gap-2">
                       <button
-                        onClick={() => agreementMutation.mutate(agreementForm)}
+                        onClick={() => {
+                          setConfirmDialog({
+                            fromStatus: currentStatus,
+                            toStatus: 'agreement_sent',
+                            onConfirm: () => agreementMutation.mutate(agreementForm),
+                          })
+                        }}
                         disabled={agreementMutation.isPending}
                         className="flex-1 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
                       >
-                        {agreementMutation.isPending ? t('common.loading') : t('contract.sendOffer')}
+                        {agreementMutation.isPending ? t('common.loading') : t('action.sendAgreement')}
                       </button>
                       <button
                         onClick={() => setShowAgreementForm(false)}
@@ -1597,6 +1604,72 @@ export default function AthletePage() {
           </div>
         )}
       </div>
+
+      {/* Transition confirmation dialog */}
+      {confirmDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={() => setConfirmDialog(null)}>
+          <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 p-6" onClick={e => e.stopPropagation()}>
+            <p className="text-sm text-gray-900 mb-5 leading-relaxed">
+              {t(`confirm.transition.${confirmDialog.fromStatus}__${confirmDialog.toStatus}`, {
+                athlete: `${athlete.firstName} ${athlete.lastName}`,
+                meeting: athlete.edition?.name ?? '',
+              })}
+            </p>
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => setConfirmDialog(null)}
+                className="text-xs px-3 py-1.5 rounded border border-gray-300 hover:bg-gray-50"
+              >
+                {t('common.cancel')}
+              </button>
+              <button
+                onClick={() => confirmDialog.onConfirm()}
+                disabled={statusMutation.isPending || agreementMutation.isPending}
+                className={`text-xs px-3 py-1.5 rounded font-medium text-white disabled:opacity-50 ${
+                  confirmDialog.toStatus === 'rejected'
+                    ? 'bg-red-600 hover:bg-red-700'
+                    : confirmDialog.toStatus === 'to_review'
+                    ? 'bg-orange-600 hover:bg-orange-700'
+                    : confirmDialog.toStatus === 'confirmed'
+                    ? 'bg-green-600 hover:bg-green-700'
+                    : confirmDialog.toStatus === 'withdrawn'
+                    ? 'bg-gray-600 hover:bg-gray-700'
+                    : 'bg-blue-600 hover:bg-blue-700'
+                }`}
+              >
+                {t('common.confirm')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Email preview modal — shown after each status transition */}
+      {emailPreview && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={() => setEmailPreview(null)}>
+          <div className="bg-white rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[80vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
+            <div className="flex items-center justify-between p-4 border-b">
+              <h3 className="font-semibold text-sm">{t('emailPreview.title')}</h3>
+              <button onClick={() => setEmailPreview(null)} className="text-gray-400 hover:text-gray-600">✕</button>
+            </div>
+            <div className="p-4 text-sm space-y-3">
+              <p className="text-xs text-gray-500">{t('emailPreview.description')}</p>
+              <div className="text-xs text-gray-700">
+                <span className="font-medium">{t('emailPreview.subject')}:</span> {emailPreview.subject}
+              </div>
+              <pre className="text-xs text-gray-700 whitespace-pre-wrap bg-gray-50 p-3 rounded border">{emailPreview.body}</pre>
+              <div className="flex justify-end">
+                <button
+                  onClick={() => setEmailPreview(null)}
+                  className="text-xs px-4 py-1.5 rounded font-medium bg-gray-900 text-white hover:bg-gray-800"
+                >
+                  {t('common.close')}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Email popup modal */}
       {viewingEmailId && (


### PR DESCRIPTION
Implémentation complète de la révision du workflow des statuts de négociation dans la page athlète.

## Changements

- Mise à jour des libellés de statuts (EN/FR)
- Contrôle des boutons d'action par rôle et statut
- Popups de confirmation spécifiques à chaque transition
- Aperçu email après chaque transition
- Validation "au moins 1 sélectionné" avant envoi accord

Fixes issue #27

Generated with [Claude Code](https://claude.ai/code)