### PR TITLE
feat: open athlete page on Agreement & Négociation tab by default

### DIFF
--- a/src/web/pages/collaborator/AthletePage.tsx
+++ b/src/web/pages/collaborator/AthletePage.tsx
@@ -659,7 +659,7 @@ export default function AthletePage() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
 
-  const [activeTab, setActiveTab] = useState<'personal' | 'negotiation'>('personal')
+  const [activeTab, setActiveTab] = useState<'personal' | 'negotiation'>('negotiation')
   const [openSection, setOpenSection] = useState<string | null>('identity')
   const [editingSection, setEditingSection] = useState<string | null>(null)
   const [confirmDialog, setConfirmDialog] = useState<{


### PR DESCRIPTION
Closes #29

Ouvre la page athlète sur l'onglet "Agreement & Négociation" par défaut plutôt que "Personal data".

**Changement :** valeur initiale du state `activeTab` dans `AthletePage.tsx` modifiée de `'personal'` à `'negotiation'`.

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/OlivierLmr/atleticageneve/tree/claude/issue-29-20260422-1220