### PR TITLE
feat: afficher le mail envoyé en réponse à une demande de lien de connexion

### DIFF
--- a/src/api/routes/auth.ts
+++ b/src/api/routes/auth.ts
@@ -120,6 +120,7 @@ auth.post('/identify', async (c) => {
   }
 
   // User is athlete/manager → send magic link
+  let emailPreview: { subject: string; body: string } | undefined
   if (user.email) {
     const token = generateToken()
     await db.insert(schema.magicLink).values({
@@ -129,10 +130,11 @@ auth.post('/identify', async (c) => {
     })
     const baseUrl = c.req.header('Origin') ?? 'http://localhost:5173'
     const lang = (user.preferredLang as 'en' | 'fr') ?? 'en'
-    await sendMagicLinkEmail(db, user.email, token, baseUrl, lang)
+    const result = await sendMagicLinkEmail(db, user.email, token, baseUrl, lang)
+    emailPreview = { subject: result.subject, body: result.body }
   }
 
-  return c.json({ method: 'magic_link', message: 'If this email is registered, a login link has been sent.' })
+  return c.json({ method: 'magic_link', message: 'If this email is registered, a login link has been sent.', emailPreview })
 })
 
 // ── POST /auth/login-with-password — for identified password users ────────────

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -198,6 +198,7 @@ function HomePage() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+  const [emailPreview, setEmailPreview] = useState<{ subject: string; body: string } | null>(null)
 
   // If already logged in, redirect to the right portal
   if (user && !loading) {
@@ -235,11 +236,15 @@ function HomePage() {
     setError('')
     setLoading(true)
     try {
-      const res = await api.post<{ method: string }>('/api/v1/auth/identify', { identifier: email.trim() })
+      const res = await api.post<{ method: string; emailPreview?: { subject: string; body: string } }>(
+        '/api/v1/auth/identify',
+        { identifier: email.trim() },
+      )
       if (res.method === 'not_found') {
         setError(t('auth.notRegistered'))
       } else {
         setMode('magic_link_sent')
+        if (res.emailPreview) setEmailPreview(res.emailPreview)
       }
     } catch (err) {
       setError(err instanceof ApiError ? err.message : t('common.error'))
@@ -254,6 +259,7 @@ function HomePage() {
     setEmail('')
     setPassword('')
     setError('')
+    setEmailPreview(null)
   }
 
   return (
@@ -369,6 +375,28 @@ function HomePage() {
         )}
       </div>
 
+      {emailPreview && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 px-4">
+          <div className="w-full max-w-lg bg-white rounded-lg border shadow-xl p-6">
+            <h2 className="font-bold text-sm mb-1">{t('emailPreview.title')}</h2>
+            <p className="text-xs text-gray-500 mb-4">{t('emailPreview.description')}</p>
+            <div className="bg-gray-50 rounded border p-4 text-xs space-y-3 mb-6">
+              <div>
+                <span className="font-semibold text-gray-600">{t('emailPreview.subject')} :</span>{' '}
+                <span>{emailPreview.subject}</span>
+              </div>
+              <hr />
+              <pre className="whitespace-pre-wrap font-sans leading-relaxed">{emailPreview.body}</pre>
+            </div>
+            <button
+              onClick={() => setEmailPreview(null)}
+              className="w-full px-4 py-2 text-sm bg-gray-900 text-white rounded-md hover:bg-gray-800"
+            >
+              {t('common.close')}
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Ferme #33

Affiche une popup avec le contenu du mail envoyé lors d'une demande de lien de connexion, cohérent avec le flux d'inscription athlète existant.

Generated with [Claude Code](https://claude.ai/code)