### PR TITLE
feat: Standardized agreement terms display and email formatting

### DIFF
--- a/src/api/routes/agreements.ts
+++ b/src/api/routes/agreements.ts
@@ -4,6 +4,7 @@ import * as schema from '../db/schema'
 import { agreementSchema } from '@shared/validation'
 import { requireAuth } from '../middleware/auth'
 import { sendEmail, buildTransitionEmail } from '../services/email'
+import { formatAgreementTerms } from '@shared/agreementFormatter'
 import type { Env } from '../index'
 import type { NegotiationStatus, ParticipationStatus } from '@shared/types'
 
@@ -96,25 +97,35 @@ agreements.post('/:athleteId/agreements', async (c) => {
     }, 400)
   }
 
-  // Precondition: ALL athlete's applications must have participationStatus != 'pending'
-  const apps = await db
-    .select()
+  // Fetch all applications with event + catalog (needed for status checks and event names)
+  const appsWithDetails = await db
+    .select({
+      application: schema.application,
+      catalogName: schema.eventCatalog.name,
+      catalogGender: schema.eventCatalog.gender,
+    })
     .from(schema.application)
+    .innerJoin(schema.event, eq(schema.application.eventId, schema.event.id))
+    .innerJoin(schema.eventCatalog, eq(schema.event.catalogId, schema.eventCatalog.id))
     .where(eq(schema.application.athleteId, athleteId))
 
-  const hasPending = apps.some(a => (a.participationStatus as ParticipationStatus) === 'pending')
+  const hasPending = appsWithDetails.some(r => (r.application.participationStatus as ParticipationStatus) === 'pending')
   if (hasPending) {
     return c.json({
       error: 'All applications must have a participation decision (selected/not_selected) before sending an agreement',
     }, 400)
   }
 
-  const hasSelected = apps.some(a => (a.participationStatus as ParticipationStatus) === 'selected')
+  const hasSelected = appsWithDetails.some(r => (r.application.participationStatus as ParticipationStatus) === 'selected')
   if (!hasSelected) {
     return c.json({
       error: 'At least one application must be selected before sending an agreement',
     }, 400)
   }
+
+  const selectedEventNames = appsWithDetails
+    .filter(r => (r.application.participationStatus as ParticipationStatus) === 'selected')
+    .map(r => `${r.catalogName} ${r.catalogGender === 'M' ? 'Men' : 'Women'}`)
 
   // Get edition costs
   const editions = await db.select().from(schema.edition).limit(1)
@@ -123,16 +134,24 @@ agreements.post('/:athleteId/agreements', async (c) => {
   }
   const edition = editions[0]
 
-  // Get hotel room costs if specified
+  // Get hotel room costs and hotel name if specified
   let roomCosts: RoomCosts = { costPerNight: 0, dinnerCost: 0 }
+  let hotelName: string | null = null
+  let hotelRoomType: string | null = null
   if (data.hotelRoomId) {
-    const rooms = await db
-      .select()
+    const roomRows = await db
+      .select({
+        room: schema.hotelRoom,
+        hotelName: schema.hotel.name,
+      })
       .from(schema.hotelRoom)
+      .leftJoin(schema.hotel, eq(schema.hotelRoom.hotelId, schema.hotel.id))
       .where(eq(schema.hotelRoom.id, data.hotelRoomId))
       .limit(1)
-    if (rooms.length > 0) {
-      roomCosts = { costPerNight: rooms[0].costPerNight, dinnerCost: rooms[0].dinnerCost }
+    if (roomRows.length > 0) {
+      roomCosts = { costPerNight: roomRows[0].room.costPerNight, dinnerCost: roomRows[0].room.dinnerCost }
+      hotelName = roomRows[0].hotelName ?? null
+      hotelRoomType = roomRows[0].room.roomType ?? null
     }
   }
 
@@ -204,6 +223,43 @@ agreements.post('/:athleteId/agreements', async (c) => {
     authorName: `${user.firstName} ${user.lastName}`,
   })
 
+  // Build the agreement object with hotel info for formatting
+  const agreementForFormat = {
+    id: agreementId,
+    athleteId,
+    version: nextVersion,
+    direction: 'to_athlete' as const,
+    appearanceFee: data.appearanceFee,
+    otherCompensation: data.otherCompensation,
+    otherCompensationDesc: data.otherCompensationDesc ?? null,
+    transport: data.transport,
+    transportAirportHotel: data.transportAirportHotel,
+    transportHotelStadium: data.transportHotelStadium,
+    hotelRoomId: data.hotelRoomId ?? null,
+    hotelNightTue: data.hotelNightTue,
+    hotelNightWed: data.hotelNightWed,
+    hotelNightThu: data.hotelNightThu,
+    hotelNightFri: data.hotelNightFri,
+    hotelNightSat: data.hotelNightSat,
+    hotelNightSun: data.hotelNightSun,
+    dinnerTue: data.dinnerTue,
+    dinnerWed: data.dinnerWed,
+    dinnerThu: data.dinnerThu,
+    dinnerFri: data.dinnerFri,
+    dinnerSat: data.dinnerSat,
+    dinnerSun: data.dinnerSun,
+    stadiumMeals: data.stadiumMeals,
+    notes: data.notes ?? null,
+    totalCost,
+    sentBy: user.id,
+    sentAt: now,
+    createdAt: now,
+    hotelName,
+    hotelRoomType,
+  }
+
+  const agreementTerms = formatAgreementTerms(agreementForFormat, selectedEventNames, edition.name, 'en')
+
   // Build transition email for agreement_sent
   const athleteName = `${ath.firstName} ${ath.lastName}`
   const meetingName = edition.name
@@ -228,6 +284,7 @@ agreements.post('/:athleteId/agreements', async (c) => {
     senderName,
     recipientName,
     organizationName,
+    agreementTerms,
   })
 
   if (transitionEmail) {

--- a/src/api/routes/athletes.ts
+++ b/src/api/routes/athletes.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { zValidator } from '@hono/zod-validator'
-import { eq, sql } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import * as schema from '../db/schema'
 import { athleteRegistrationSchema, batchAthleteRegistrationSchema, athleteUpdateSchema, negotiationStatusChangeSchema } from '@shared/validation'
 import { NEGOTIATION_TRANSITIONS, COMMITTEE_EXTRA_TRANSITIONS, ATHLETE_TRANSITIONS } from '@shared/constants'
@@ -292,12 +292,24 @@ athletes.get('/:id', requireAuth('athlete', 'manager', 'collaborator', 'committe
     waPerformance: waPerfMap.get(r.application.eventId) ?? null,
   }))
 
-  // Fetch agreements
-  const rawAgreements = await db
-    .select()
+  // Fetch agreements with hotel name and room type
+  const rawAgreementRows = await db
+    .select({
+      agreement: schema.agreement,
+      hotelName: schema.hotel.name,
+      hotelRoomType: schema.hotelRoom.roomType,
+    })
     .from(schema.agreement)
+    .leftJoin(schema.hotelRoom, eq(schema.agreement.hotelRoomId, schema.hotelRoom.id))
+    .leftJoin(schema.hotel, eq(schema.hotelRoom.hotelId, schema.hotel.id))
     .where(eq(schema.agreement.athleteId, id))
     .orderBy(schema.agreement.version)
+
+  const rawAgreements = rawAgreementRows.map(r => ({
+    ...r.agreement,
+    hotelName: r.hotelName ?? null,
+    hotelRoomType: r.hotelRoomType ?? null,
+  }))
 
   // Strip totalCost from agreements for athlete/manager view
   const agreements = isStaff
@@ -455,6 +467,20 @@ athletes.patch('/:id/negotiation-status', requireAuth('athlete', 'manager', 'col
     }
   }
 
+  // For athlete/manager counter-offer transition, look up the most recent counter-offer text
+  let counterOfferText: string | undefined
+  if (currentStatus === 'agreement_sent' && newStatus === 'counter_offer_sent') {
+    const counterOfferRows = await db
+      .select()
+      .from(schema.interaction)
+      .where(and(eq(schema.interaction.athleteId, id), eq(schema.interaction.type, 'counter_offer')))
+      .orderBy(sql`${schema.interaction.createdAt} DESC`)
+      .limit(1)
+    if (counterOfferRows.length > 0) {
+      counterOfferText = counterOfferRows[0].content
+    }
+  }
+
   const transitionEmail = buildTransitionEmail({
     from: currentStatus,
     to: newStatus,
@@ -463,6 +489,7 @@ athletes.patch('/:id/negotiation-status', requireAuth('athlete', 'manager', 'col
     senderName,
     recipientName,
     organizationName,
+    counterOfferText,
   })
 
   let emailLogId: string | null = null

--- a/src/api/services/email.ts
+++ b/src/api/services/email.ts
@@ -77,16 +77,22 @@ export function buildTransitionEmail(params: {
   senderName: string
   recipientName: string
   organizationName: string
+  agreementTerms?: string
+  counterOfferText?: string
 }): TransitionEmail | null {
-  const { from, to, athleteName, meetingName, senderName, recipientName, organizationName } = params
+  const { from, to, athleteName, meetingName, senderName, recipientName, organizationName, agreementTerms, counterOfferText } = params
   const key = `${from}__${to}`
 
   switch (key) {
-    case 'to_review__agreement_sent':
+    case 'to_review__agreement_sent': {
+      const termsSection = agreementTerms
+        ? `\n\nHere are the terms of our offer:\n\n${agreementTerms}`
+        : ''
       return {
         subject: `${meetingName} — Participation Agreement`,
-        body: `Dear ${recipientName},\n\nWe are pleased to inform you that we have reviewed ${athleteName}'s application for ${meetingName} and are ready to move forward with a participation offer.\n\nPlease find attached the participation agreement for your review. We would be grateful if you could let us know your decision at your earliest convenience.\n\nShould you have any questions or wish to discuss any aspect of the agreement, please do not hesitate to reach out.\n\nWe look forward to hearing from you.\n\nKind regards,\n${senderName} — ${organizationName}`,
+        body: `Dear ${recipientName},\n\nWe are pleased to inform you that we have reviewed ${athleteName}'s application for ${meetingName} and are ready to move forward with a participation offer.${termsSection}\n\nPlease let us know your decision at your earliest convenience. Should you have any questions or wish to discuss any aspect of the offer, please do not hesitate to reach out.\n\nKind regards,\n${senderName} — ${organizationName}`,
       }
+    }
     case 'to_review__rejected':
       return {
         subject: `${meetingName} — Application Update`,
@@ -102,21 +108,29 @@ export function buildTransitionEmail(params: {
         subject: `${meetingName} — Agreement Accepted`,
         body: `Dear ${recipientName},\n\nWe are delighted to confirm ${athleteName}'s participation in ${meetingName} on the terms set out in the agreement.\n\nWe look forward to the event and thank you for the opportunity.\n\nKind regards,\n${senderName}`,
       }
-    case 'agreement_sent__counter_offer_sent':
+    case 'agreement_sent__counter_offer_sent': {
+      const counterSection = counterOfferText
+        ? `\n\nHere is our counter-proposal:\n\n${counterOfferText}`
+        : '\n\nPlease find our counter-offer attached.'
       return {
         subject: `${meetingName} — Counter-offer`,
-        body: `Dear ${recipientName},\n\nThank you for sending the participation agreement for ${athleteName} at ${meetingName}.\n\nHaving reviewed the proposed terms, we would like to suggest some adjustments. Please find our counter-offer attached.\n\nWe remain open to discussion and look forward to reaching a mutually satisfactory agreement.\n\nKind regards,\n${senderName}`,
+        body: `Dear ${recipientName},\n\nThank you for sending the participation agreement for ${athleteName} at ${meetingName}.\n\nHaving reviewed the proposed terms, we would like to suggest some adjustments.${counterSection}\n\nWe remain open to discussion and look forward to reaching a mutually satisfactory agreement.\n\nKind regards,\n${senderName}`,
       }
+    }
     case 'agreement_sent__withdrawn':
       return {
         subject: `${meetingName} — Withdrawal`,
         body: `Dear ${recipientName},\n\nAfter careful consideration, we regret to inform you that ${athleteName} must withdraw from ${meetingName}.\n\nWe are sorry for any inconvenience this may cause and sincerely thank you for the opportunity that was extended. We hope to be able to collaborate at a future event.\n\nKind regards,\n${senderName}`,
       }
-    case 'counter_offer_sent__agreement_sent':
+    case 'counter_offer_sent__agreement_sent': {
+      const termsSection = agreementTerms
+        ? `\n\nHere are the revised terms:\n\n${agreementTerms}`
+        : ''
       return {
         subject: `${meetingName} — Updated Participation Agreement`,
-        body: `Dear ${recipientName},\n\nThank you for your counter-offer regarding ${athleteName}'s participation in ${meetingName}. We have taken your points into consideration and are pleased to send you an updated participation agreement.\n\nWe hope this revised proposal meets your expectations. Please do not hesitate to contact us if you have any further questions.\n\nKind regards,\n${senderName} — ${organizationName}`,
+        body: `Dear ${recipientName},\n\nThank you for your counter-offer regarding ${athleteName}'s participation in ${meetingName}. We have taken your points into consideration and are pleased to send you an updated participation offer.${termsSection}\n\nWe hope this revised proposal meets your expectations. Please do not hesitate to contact us if you have any further questions.\n\nKind regards,\n${senderName} — ${organizationName}`,
       }
+    }
     case 'counter_offer_sent__rejected':
       return {
         subject: `${meetingName} — End of Negotiations`,

--- a/src/shared/agreementFormatter.ts
+++ b/src/shared/agreementFormatter.ts
@@ -1,0 +1,173 @@
+import type { Agreement } from './types'
+
+type Lang = 'en' | 'fr'
+
+const MONTHS_EN = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+]
+const MONTHS_FR = [
+  'janvier', 'février', 'mars', 'avril', 'mai', 'juin',
+  'juillet', 'août', 'septembre', 'octobre', 'novembre', 'décembre',
+]
+
+function formatDate(dateStr: string, lang: Lang): string {
+  const d = new Date(dateStr)
+  const day = d.getUTCDate()
+  const month = lang === 'fr' ? MONTHS_FR[d.getUTCMonth()] : MONTHS_EN[d.getUTCMonth()]
+  const year = d.getUTCFullYear()
+  return `${day} ${month} ${year}`
+}
+
+function formatAmount(amount: number, lang: Lang): string {
+  const sep = lang === 'fr' ? "'" : ','
+  const formatted = Math.round(amount).toString().replace(/\B(?=(\d{3})+(?!\d))/g, sep)
+  return `CHF ${formatted}`
+}
+
+const DAY_LABELS: Record<Lang, Record<string, string>> = {
+  en: { tue: 'Tuesday', wed: 'Wednesday', thu: 'Thursday', fri: 'Friday', sat: 'Saturday', sun: 'Sunday' },
+  fr: { tue: 'mardi', wed: 'mercredi', thu: 'jeudi', fri: 'vendredi', sat: 'samedi', sun: 'dimanche' },
+}
+
+function getActiveDays(
+  values: { tue: boolean; wed: boolean; thu: boolean; fri: boolean; sat: boolean; sun: boolean },
+  lang: Lang,
+): string[] {
+  const labels = DAY_LABELS[lang]
+  return (['tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const)
+    .filter(k => values[k])
+    .map(k => labels[k])
+}
+
+export interface AgreementWithHotel extends Agreement {
+  hotelName?: string | null
+  hotelRoomType?: string | null
+}
+
+export function formatAgreementTerms(
+  agreement: AgreementWithHotel,
+  selectedEventNames: string[],
+  meetingName: string,
+  lang: Lang,
+): string {
+  const colon = lang === 'fr' ? ' :' : ':'
+
+  const title = lang === 'fr' ? "Accord d'invitation" : 'Invitation Agreement'
+  const sentDateStr = formatDate(agreement.sentAt, lang)
+
+  const lines: string[] = []
+
+  lines.push(`${title} — version ${agreement.version}`)
+  lines.push(`${meetingName} · ${sentDateStr}`)
+  lines.push('')
+
+  const eventsLabel = lang === 'fr' ? 'Épreuves sélectionnées' : 'Selected events'
+  lines.push(`${eventsLabel}${colon}`)
+  for (const name of selectedEventNames) {
+    lines.push(`  • ${name}`)
+  }
+
+  const terms: string[] = []
+
+  if (agreement.appearanceFee > 0) {
+    const label = lang === 'fr' ? 'Cachet de participation' : 'Appearance fee'
+    terms.push(`${label}${colon} ${formatAmount(agreement.appearanceFee, lang)}`)
+  }
+
+  if (agreement.otherCompensation > 0) {
+    const baseLabel = lang === 'fr' ? 'Autre compensation' : 'Other compensation'
+    const label = agreement.otherCompensationDesc
+      ? `${baseLabel} (${agreement.otherCompensationDesc})`
+      : baseLabel
+    terms.push(`${label}${colon} ${formatAmount(agreement.otherCompensation, lang)}`)
+  }
+
+  if (agreement.transport > 0) {
+    const label = lang === 'fr' ? 'Indemnité forfaitaire de transport' : 'Flat-rate transport allowance'
+    terms.push(`${label}${colon} ${formatAmount(agreement.transport, lang)}`)
+  }
+
+  if (agreement.transportAirportHotel) {
+    const label = lang === 'fr' ? 'Transport aéroport → hôtel' : 'Airport → hotel transfer'
+    const value = lang === 'fr' ? 'inclus' : 'included'
+    terms.push(`${label}${colon} ${value}`)
+  }
+
+  if (agreement.transportHotelStadium) {
+    const label = lang === 'fr' ? 'Transport hôtel → stade' : 'Hotel → stadium transfer'
+    const value = lang === 'fr' ? 'inclus' : 'included'
+    terms.push(`${label}${colon} ${value}`)
+  }
+
+  const nightDays = getActiveDays({
+    tue: agreement.hotelNightTue,
+    wed: agreement.hotelNightWed,
+    thu: agreement.hotelNightThu,
+    fri: agreement.hotelNightFri,
+    sat: agreement.hotelNightSat,
+    sun: agreement.hotelNightSun,
+  }, lang)
+
+  const dinnerDays = getActiveDays({
+    tue: agreement.dinnerTue,
+    wed: agreement.dinnerWed,
+    thu: agreement.dinnerThu,
+    fri: agreement.dinnerFri,
+    sat: agreement.dinnerSat,
+    sun: agreement.dinnerSun,
+  }, lang)
+
+  if (nightDays.length > 0 || dinnerDays.length > 0) {
+    const hospiLabel = lang === 'fr' ? 'Hospitalité' : 'Hospitality'
+    const hotelPart = agreement.hotelName ? ` — ${agreement.hotelName}` : ''
+    terms.push(`${hospiLabel}${hotelPart}${colon}`)
+
+    if (nightDays.length > 0) {
+      const n = nightDays.length
+      const nightsStr = lang === 'fr'
+        ? `${n} nuit${n > 1 ? 's' : ''}`
+        : `${n} night${n > 1 ? 's' : ''}`
+      const roomPart = agreement.hotelRoomType
+        ? (lang === 'fr' ? ` — chambre ${agreement.hotelRoomType}` : ` — ${agreement.hotelRoomType} room`)
+        : ''
+      const accomLabel = lang === 'fr' ? 'Hébergement' : 'Accommodation'
+      terms.push(`    - ${accomLabel}${colon} ${nightsStr} (${nightDays.join(', ')})${roomPart}`)
+    }
+
+    if (dinnerDays.length > 0) {
+      const n = dinnerDays.length
+      const dinnersStr = lang === 'fr'
+        ? `${n} dîner${n > 1 ? 's' : ''}`
+        : `${n} dinner${n > 1 ? 's' : ''}`
+      const dinnersLabel = lang === 'fr' ? 'Dîners' : 'Dinners'
+      terms.push(`    - ${dinnersLabel}${colon} ${dinnersStr} (${dinnerDays.join(', ')})`)
+    }
+  }
+
+  if (agreement.stadiumMeals) {
+    const label = lang === 'fr' ? 'Repas au stade' : 'Stadium meals'
+    const value = lang === 'fr' ? 'inclus' : 'included'
+    terms.push(`${label}${colon} ${value}`)
+  }
+
+  if (terms.length > 0) {
+    lines.push('')
+    const termsLabel = lang === 'fr' ? "Conditions de l'accord" : 'Agreement terms'
+    lines.push(`${termsLabel}${colon}`)
+    for (const term of terms) {
+      if (term.startsWith('    -')) {
+        lines.push(term)
+      } else {
+        lines.push(`  • ${term}`)
+      }
+    }
+  }
+
+  if (agreement.notes) {
+    lines.push('')
+    lines.push(`Note${colon} ${agreement.notes}`)
+  }
+
+  return lines.join('\n')
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -212,6 +212,8 @@ export interface Agreement {
   sentBy: string | null
   sentAt: string
   createdAt: string
+  hotelName?: string | null
+  hotelRoomType?: string | null
 }
 
 export interface Hotel {

--- a/src/web/pages/collaborator/AthletePage.tsx
+++ b/src/web/pages/collaborator/AthletePage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { formatAgreementTerms } from '@shared/agreementFormatter'
 import { Link, useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { api } from '@web/lib/api'
@@ -274,46 +275,44 @@ function SelectorAssign({ currentValue, staffUsers, onSave, isPending, t }: {
   )
 }
 
-function AgreementCard({ agreement: c, t, isStaff }: { agreement: Agreement; t: (key: string) => string; isStaff: boolean }) {
-  const nights = [
-    c.hotelNightTue, c.hotelNightWed, c.hotelNightThu,
-    c.hotelNightFri, c.hotelNightSat, c.hotelNightSun,
-  ].filter(Boolean).length
-
-  const dinners = [
-    c.dinnerTue, c.dinnerWed, c.dinnerThu,
-    c.dinnerFri, c.dinnerSat, c.dinnerSun,
-  ].filter(Boolean).length
-
-  // Only show non-empty fields (Phase 5.2 requirement)
-  const rows: Array<{ label: string; value: string }> = []
-  if (c.appearanceFee > 0) rows.push({ label: t('contract.bonus'), value: `CHF ${c.appearanceFee}` })
-  if (c.otherCompensation > 0) rows.push({ label: t('contract.otherCompensation'), value: `CHF ${c.otherCompensation}` })
-  if (c.transport > 0) rows.push({ label: t('contract.transport'), value: `CHF ${c.transport}` })
-  if (nights > 0) rows.push({ label: t('contract.hotelNights'), value: String(nights) })
-  if (dinners > 0) rows.push({ label: t('contract.dinners'), value: String(dinners) })
+function AgreementCard({
+  agreement: c,
+  selectedEventNames,
+  meetingName,
+  lang,
+  isStaff,
+  t,
+}: {
+  agreement: Agreement
+  selectedEventNames: string[]
+  meetingName: string
+  lang: string
+  isStaff: boolean
+  t: (key: string) => string
+}) {
+  const formattedLang = (lang === 'fr' ? 'fr' : 'en') as 'en' | 'fr'
+  const formattedText = formatAgreementTerms(c, selectedEventNames, meetingName, formattedLang)
 
   return (
-    <div className={`p-3 rounded border text-xs ${
-      c.direction === 'to_athlete' ? 'border-blue-200 bg-blue-50' : 'border-purple-200 bg-purple-50'
-    }`}>
-      <div className="flex justify-between mb-1">
-        <span className="font-semibold">
-          v{c.version} — {c.direction === 'to_athlete' ? t('contract.toAthlete') : t('contract.counterOffer')}
-        </span>
-        <span className="text-gray-500">{new Date(c.sentAt).toLocaleDateString()}</span>
-      </div>
-      {rows.length > 0 && (
-        <div className="grid grid-cols-2 gap-1 text-gray-600">
-          {rows.map(r => <span key={r.label}>{r.label}: {r.value}</span>)}
-        </div>
-      )}
+    <div className="p-3 rounded border border-blue-200 bg-blue-50 text-xs">
+      <pre className="whitespace-pre-wrap font-sans text-gray-700 leading-relaxed">{formattedText}</pre>
       {isStaff && c.totalCost > 0 && (
-        <div className="mt-1 font-semibold text-gray-900">
+        <div className="mt-2 pt-2 border-t border-blue-200 font-semibold text-gray-900">
           {t('contract.totalCost')}: CHF {c.totalCost.toLocaleString()}
         </div>
       )}
-      {c.notes && <p className="mt-1 text-gray-500 italic">{c.notes}</p>}
+    </div>
+  )
+}
+
+function CounterOfferCard({ interaction }: { interaction: Interaction }) {
+  return (
+    <div className="p-3 rounded border border-rose-200 bg-rose-50 text-xs">
+      <div className="flex justify-between mb-1">
+        <span className="font-semibold text-rose-700">{interaction.authorName}</span>
+        <span className="text-gray-500">{new Date(interaction.createdAt).toLocaleDateString()}</span>
+      </div>
+      <p className="text-gray-700 whitespace-pre-wrap">{interaction.content}</p>
     </div>
   )
 }
@@ -677,7 +676,7 @@ function CostPopup({ athlete, latestAgreement, costMode, t }: {
 // ── Main page ────────────────────────────────────────────────────────────────
 
 export default function AthletePage() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const { id } = useParams<{ id: string }>()
   const { user } = useAuth()
   const navigate = useNavigate()
@@ -1397,17 +1396,61 @@ export default function AthletePage() {
                   )}
                 </div>
 
-                {currentStatus === 'confirmed' && athlete.agreements.length === 0 ? (
-                  <p className="text-sm text-green-700 italic">{t('selection.acceptedAtMeeting')}</p>
-                ) : athlete.agreements.length === 0 ? (
-                  <p className="text-xs text-gray-400">{t('contract.noOfferYet')}</p>
-                ) : (
-                  <div className="space-y-3">
-                    {athlete.agreements.map(c => (
-                      <AgreementCard key={c.id} agreement={c} t={t} isStaff={!!isStaff} />
-                    ))}
-                  </div>
-                )}
+                {(() => {
+                  const selectedEventNames = athlete.applications
+                    .filter(a => a.participationStatus === 'selected')
+                    .map(a => `${a.event.catalog.name} ${a.event.catalog.gender === 'M' ? (i18n.language === 'fr' ? 'Hommes' : 'Men') : (i18n.language === 'fr' ? 'Femmes' : 'Women')}`)
+                  const meetingName = athlete.edition?.name ?? 'Atletica Geneve'
+
+                  type TimelineItem =
+                    | { kind: 'agreement'; id: string; date: string; data: Agreement }
+                    | { kind: 'counter_offer'; id: string; date: string; data: Interaction }
+
+                  const agreementItems: TimelineItem[] = athlete.agreements.map(a => ({
+                    kind: 'agreement' as const,
+                    id: a.id,
+                    date: a.sentAt,
+                    data: a,
+                  }))
+
+                  const counterOfferItems: TimelineItem[] = athlete.interactions
+                    .filter(i => i.type === 'counter_offer')
+                    .map(i => ({
+                      kind: 'counter_offer' as const,
+                      id: i.id,
+                      date: i.createdAt,
+                      data: i,
+                    }))
+
+                  const timelineItems = [...agreementItems, ...counterOfferItems]
+                    .sort((a, b) => a.date.localeCompare(b.date))
+
+                  if (currentStatus === 'confirmed' && timelineItems.length === 0) {
+                    return <p className="text-sm text-green-700 italic">{t('selection.acceptedAtMeeting')}</p>
+                  }
+                  if (timelineItems.length === 0) {
+                    return <p className="text-xs text-gray-400">{t('contract.noOfferYet')}</p>
+                  }
+                  return (
+                    <div className="space-y-3">
+                      {timelineItems.map(item =>
+                        item.kind === 'agreement'
+                          ? (
+                            <AgreementCard
+                              key={item.id}
+                              agreement={item.data}
+                              selectedEventNames={selectedEventNames}
+                              meetingName={meetingName}
+                              lang={i18n.language}
+                              isStaff={!!isStaff}
+                              t={t}
+                            />
+                          )
+                          : <CounterOfferCard key={item.id} interaction={item.data} />
+                      )}
+                    </div>
+                  )
+                })()}
               </div>
 
             </div>


### PR DESCRIPTION
Implements issue #22: standardized presentation of agreement terms.

## Changes

- New `agreementFormatter.ts` shared utility for consistent EN/FR formatting
- Agreement API extended with hotel name and room type resolution
- Emails now include formatted agreement terms (staff offers) and counter-offer text (athlete/manager)
- AgreementCard redesigned to show structured text
- Counter-offer pink boxes interleaved chronologically with blue agreement boxes

Generated with [Claude Code](https://claude.ai/code)