### PR TITLE
Sort agreement/counter-offer timeline in reverse chronological order

### DIFF
--- a/src/web/pages/collaborator/AthletePage.tsx
+++ b/src/web/pages/collaborator/AthletePage.tsx
@@ -1423,7 +1423,7 @@ export default function AthletePage() {
                     }))
 
                   const timelineItems = [...agreementItems, ...counterOfferItems]
-                    .sort((a, b) => a.date.localeCompare(b.date))
+                    .sort((a, b) => b.date.localeCompare(a.date))
 
                   if (currentStatus === 'confirmed' && timelineItems.length === 0) {
                     return <p className="text-sm text-green-700 italic">{t('selection.acceptedAtMeeting')}</p>


### PR DESCRIPTION
Sort the merged agreement and counter-offer timeline so the most recent item appears first.

Fixes #37

Generated with [Claude Code](https://claude.ai/code)