### PR TITLE
Fix timeline sort: normalize date formats before comparing

### DIFF
--- a/src/api/routes/athletes.ts
+++ b/src/api/routes/athletes.ts
@@ -83,6 +83,7 @@ athletes.post('/', zValidator('json', athleteRegistrationSchema), async (c) => {
       type: 'status_change',
       content: 'Application submitted',
       authorName: `${data.firstName} ${data.lastName}`,
+      createdAt: new Date().toISOString(),
     })
   }
 
@@ -217,6 +218,7 @@ athletes.post('/batch', requireAuth('manager'), zValidator('json', batchAthleteR
         content: `Application submitted by manager ${user.firstName} ${user.lastName}`,
         authorId: user.id,
         authorName: `${user.firstName} ${user.lastName}`,
+        createdAt: new Date().toISOString(),
       })
     }
 
@@ -527,6 +529,7 @@ athletes.patch('/:id/negotiation-status', requireAuth('athlete', 'manager', 'col
     authorId: user.id,
     authorName: senderName,
     emailLogId,
+    createdAt: new Date().toISOString(),
   })
 
   return c.json({
@@ -632,6 +635,7 @@ athletes.post('/:id/interactions', requireAuth('athlete', 'manager', 'collaborat
     content,
     authorId: user.id,
     authorName: `${user.firstName} ${user.lastName}`,
+    createdAt: new Date().toISOString(),
   })
 
   return c.json({ id: interactionId }, 201)

--- a/src/web/pages/collaborator/AthletePage.tsx
+++ b/src/web/pages/collaborator/AthletePage.tsx
@@ -1422,8 +1422,11 @@ export default function AthletePage() {
                       data: i,
                     }))
 
+                  // Normalize both ISO ("2026-04-23T12:00:00.000Z") and SQLite ("2026-04-23 12:00:00") formats
+                  const toMs = (d: string) =>
+                    new Date(d.includes('T') ? d : d.replace(' ', 'T') + 'Z').getTime()
                   const timelineItems = [...agreementItems, ...counterOfferItems]
-                    .sort((a, b) => b.date.localeCompare(a.date))
+                    .sort((a, b) => toMs(b.date) - toMs(a.date))
 
                   if (currentStatus === 'confirmed' && timelineItems.length === 0) {
                     return <p className="text-sm text-green-700 italic">{t('selection.acceptedAtMeeting')}</p>


### PR DESCRIPTION
Corrige le tri de la timeline agreements/contre-offres.

Les agreements stockaient sentAt en format ISO JS ("2026-04-23T12:00:00.000Z") tandis que les interactions utilisaient le default SQLite datetime('now') ("2026-04-23 12:00:00"). Le localeCompare plaçait tous les agreements avant les contre-offres du même jour car T (84) > espace (32).

Fixes #37

Generated with [Claude Code](https://claude.ai/code)