### PR TITLE
fix: correct (object object) error in manager batch registration

### DIFF
--- a/src/api/routes/athletes.ts
+++ b/src/api/routes/athletes.ts
@@ -189,7 +189,7 @@ athletes.post('/batch', requireAuth('manager'), zValidator('json', batchAthleteR
       editionId: edition.id,
       firstName: data.firstName,
       lastName: data.lastName,
-      dateOfBirth: data.dateOfBirth,
+      dateOfBirth: data.dateOfBirth ?? null,
       nationality: data.nationality,
       gender: data.gender,
       isEap: data.isEap,

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -48,7 +48,7 @@ export const athleteRegistrationSchema = z.object({
 export const batchAthleteSchema = z.object({
   firstName: z.string().min(1),
   lastName: z.string().min(1),
-  dateOfBirth: z.string().min(1),
+  dateOfBirth: z.string().optional(),
   nationality: z.string().min(2).max(3),
   gender: z.enum(['M', 'F']),
   isEap: z.boolean().default(false),

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -20,8 +20,9 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   })
 
   if (!res.ok) {
-    const body = await res.json().catch(() => ({ error: res.statusText })) as { error?: string }
-    throw new ApiError(res.status, body.error ?? res.statusText)
+    const body = await res.json().catch(() => ({ error: res.statusText })) as { error?: unknown }
+    const errorMessage = typeof body.error === 'string' ? body.error : res.statusText
+    throw new ApiError(res.status, errorMessage)
   }
 
   return res.json()


### PR DESCRIPTION
Fixes #40

Two root causes:
1. `batchAthleteSchema` required `dateOfBirth` (`z.string().min(1)`) but the UI treats it as optional — submitting without a date of birth failed Zod validation
2. `api.ts` assumed `body.error` is always a string, but zValidator returns a ZodError object which serializes as `[object Object]`

Generated with [Claude Code](https://claude.ai/code)