### PR TITLE
fix: corriger les erreurs d'enregistrement des niveaux de notoriété et tranches de distance

### DIFF
--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -274,7 +274,7 @@ export const costTierConfigSchema = z.object({
   nightlyRate: z.number().int().min(0),
 })
 
-export const costTierConfigsSchema = z.array(costTierConfigSchema).min(1)
+export const costTierConfigsSchema = z.array(costTierConfigSchema)
 
 // ── Cost Distance Config ──────────────────────────────────────────────────────
 
@@ -284,7 +284,7 @@ export const costDistanceConfigSchema = z.object({
   nights: z.number().int().min(0),
 })
 
-export const costDistanceConfigsSchema = z.array(costDistanceConfigSchema).min(1)
+export const costDistanceConfigsSchema = z.array(costDistanceConfigSchema)
 
 // ── EAP city ──────────────────────────────────────────────────────────────────
 

--- a/src/web/pages/committee/EditionConfigPage.tsx
+++ b/src/web/pages/committee/EditionConfigPage.tsx
@@ -209,9 +209,9 @@ function CostConfigSection({ edition, costConfigs }: { edition: Edition; costCon
 
   const saveTiers = () => {
     const payload = tiers.map(t => ({
-      tier: t.tier,
-      rankingMin: t.rankingMin ? parseInt(t.rankingMin, 10) : null,
-      rankingMax: t.rankingMax ? parseInt(t.rankingMax, 10) : null,
+      tier: parseInt(String(t.tier), 10),
+      rankingMin: t.rankingMin !== '' ? parseInt(t.rankingMin, 10) : null,
+      rankingMax: t.rankingMax !== '' ? parseInt(t.rankingMax, 10) : null,
       appearanceFee: parseInt(t.appearanceFee, 10) || 0,
       nightlyRate: parseInt(t.nightlyRate, 10) || 0,
     }))
@@ -227,7 +227,7 @@ function CostConfigSection({ edition, costConfigs }: { edition: Edition; costCon
 
   const saveDistances = () => {
     const payload = distances.map(d => ({
-      distanceMax: d.distanceMax ? parseInt(d.distanceMax, 10) : null,
+      distanceMax: d.distanceMax !== '' ? parseInt(d.distanceMax, 10) : null,
       travelCost: parseInt(d.travelCost, 10) || 0,
       nights: parseInt(d.nights, 10) || 0,
     }))


### PR DESCRIPTION
Fixes #47

## Résumé

- Correction du champ `tier` non converti en nombre dans `saveTiers()` causant un échec de validation Zod
- Suppression de la contrainte `.min(1)` sur les schémas de tableaux tier/distance
- Correction des vérifications de chaîne vide pour `rankingMin`, `rankingMax`, `distanceMax`

Generated with [Claude Code](https://claude.ai/code)