### PR TITLE
fix: corriger le bug persistant d'enregistrement des configs coût

### DIFF
--- a/src/api/db/migrate.ts
+++ b/src/api/db/migrate.ts
@@ -273,9 +273,16 @@ const MIGRATION_0003_STMTS = [
   'ALTER TABLE interaction ADD COLUMN email_log_id TEXT REFERENCES email_log(id)',
 ]
 
-const MIGRATION_0004_STMTS = [
+const MIGRATION_0004_ALTER_STMTS = [
   'ALTER TABLE edition ADD COLUMN manager_tier_bonus INTEGER NOT NULL DEFAULT 1',
   'ALTER TABLE country ADD COLUMN distance_from_gva INTEGER NOT NULL DEFAULT 0',
+]
+
+// NOTE: these were previously run with d1.exec() which can silently fail for
+// multi-line single statements ("incomplete input: SQLITE_ERROR"). They are
+// now run with prepare().run() as recommended. Migration 0005 below acts as a
+// safety net for deployments where 0004 ran but these tables were never created.
+const MIGRATION_0004_CREATE_STMTS = [
   `CREATE TABLE IF NOT EXISTS cost_tier_config (
     id TEXT PRIMARY KEY,
     edition_id TEXT NOT NULL REFERENCES edition(id),
@@ -293,6 +300,10 @@ const MIGRATION_0004_STMTS = [
     nights INTEGER NOT NULL DEFAULT 0
   )`,
 ]
+
+// Safety net: re-creates cost tables using prepare().run() in case migration
+// 0004's d1.exec() silently failed for the multi-line CREATE TABLE statements.
+const MIGRATION_0005_STMTS = MIGRATION_0004_CREATE_STMTS
 
 // Global flag: Worker instances re-use this across requests within the same isolate.
 let migrated = false
@@ -344,14 +355,30 @@ export async function ensureMigrated(d1: D1Database): Promise<void> {
   }
 
   if (!applied.has('0004_cost_estimation')) {
-    for (const stmt of MIGRATION_0004_STMTS) {
+    for (const stmt of MIGRATION_0004_ALTER_STMTS) {
       try {
         await d1.exec(stmt)
       } catch {
-        // Column/table already exists — safe to ignore.
+        // Column already exists — safe to ignore.
+      }
+    }
+    for (const stmt of MIGRATION_0004_CREATE_STMTS) {
+      try {
+        await d1.prepare(stmt).run()
+      } catch {
+        // Table already exists — safe to ignore.
       }
     }
     await d1.prepare('INSERT OR IGNORE INTO d1_migrations (name) VALUES (?)').bind('0004_cost_estimation').run()
+  }
+
+  // Safety net for deployments where migration 0004 ran but the CREATE TABLE
+  // statements failed silently due to d1.exec() mishandling multi-line SQL.
+  if (!applied.has('0005_cost_tables_fix')) {
+    for (const stmt of MIGRATION_0005_STMTS) {
+      await d1.prepare(stmt).run()
+    }
+    await d1.prepare('INSERT OR IGNORE INTO d1_migrations (name) VALUES (?)').bind('0005_cost_tables_fix').run()
   }
 
   migrated = true

--- a/src/api/db/migrations/0005_cost_tables_fix.sql
+++ b/src/api/db/migrations/0005_cost_tables_fix.sql
@@ -1,0 +1,20 @@
+-- Safety net: re-creates cost configuration tables in case migration 0004
+-- failed silently (d1.exec mishandling multi-line CREATE TABLE statements).
+
+CREATE TABLE IF NOT EXISTS cost_tier_config (
+  id TEXT PRIMARY KEY,
+  edition_id TEXT NOT NULL REFERENCES edition(id),
+  tier INTEGER NOT NULL,
+  ranking_min INTEGER,
+  ranking_max INTEGER,
+  appearance_fee INTEGER NOT NULL DEFAULT 0,
+  nightly_rate INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS cost_distance_config (
+  id TEXT PRIMARY KEY,
+  edition_id TEXT NOT NULL REFERENCES edition(id),
+  distance_max INTEGER,
+  travel_cost INTEGER NOT NULL DEFAULT 0,
+  nights INTEGER NOT NULL DEFAULT 0
+);

--- a/src/api/routes/editions.ts
+++ b/src/api/routes/editions.ts
@@ -121,8 +121,11 @@ app.put('/:id/cost-tier-configs', requireAuth('committee'), async (c) => {
     })
   }
 
-  // Recalculate estimated costs for all athletes in this edition
-  await recalculateAllAthletesForEdition(db, id)
+  try {
+    await recalculateAllAthletesForEdition(db, id)
+  } catch (err) {
+    console.error('recalculateAllAthletesForEdition failed after saving tier configs:', err)
+  }
 
   const tierConfigs = await db
     .select()
@@ -160,8 +163,11 @@ app.put('/:id/cost-distance-configs', requireAuth('committee'), async (c) => {
     })
   }
 
-  // Recalculate estimated costs for all athletes in this edition
-  await recalculateAllAthletesForEdition(db, id)
+  try {
+    await recalculateAllAthletesForEdition(db, id)
+  } catch (err) {
+    console.error('recalculateAllAthletesForEdition failed after saving distance configs:', err)
+  }
 
   const distanceConfigs = await db
     .select()

--- a/src/web/pages/committee/EditionConfigPage.tsx
+++ b/src/web/pages/committee/EditionConfigPage.tsx
@@ -328,7 +328,7 @@ function CostConfigSection({ edition, costConfigs }: { edition: Edition; costCon
             {tierMutation.isPending ? t('common.loading') : t('admin.saveTiers')}
           </button>
           {tierSaved && <span className="text-sm text-green-600">{t('admin.saved')}</span>}
-          {tierMutation.isError && <span className="text-sm text-red-600">{t('common.error')}</span>}
+          {tierMutation.isError && <span className="text-sm text-red-600">{(tierMutation.error as Error)?.message || t('common.error')}</span>}
         </div>
       </div>
 
@@ -382,7 +382,7 @@ function CostConfigSection({ edition, costConfigs }: { edition: Edition; costCon
             {distMutation.isPending ? t('common.loading') : t('admin.saveDistances')}
           </button>
           {distSaved && <span className="text-sm text-green-600">{t('admin.saved')}</span>}
-          {distMutation.isError && <span className="text-sm text-red-600">{t('common.error')}</span>}
+          {distMutation.isError && <span className="text-sm text-red-600">{(distMutation.error as Error)?.message || t('common.error')}</span>}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #47

## Résumé

La vraie cause était que la migration 0004 utilisait d1.exec() pour les instructions CREATE TABLE multi-lignes, ce qui peut échouer silencieusement sur Cloudflare D1 ("incomplete input: SQLITE_ERROR"). Les tables cost_tier_config et cost_distance_config n'étaient jamais créées.

- Migration 0004 corrigée : utilise prepare().run() pour les CREATE TABLE
- Migration 0005 ajoutée : recrée les tables IF NOT EXISTS (filet de sécurité)
- Try-catch sur recalculateAllAthletesForEdition
- Affichage du message d'erreur API réel

Generated with [Claude Code](https://claude.ai/code)