### PR TITLE
feat: Affichage du coût dans l'écran de sélection des candidats

### DIFF
--- a/src/api/routes/applications.ts
+++ b/src/api/routes/applications.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { eq, and, sql, isNull, desc } from 'drizzle-orm'
+import { eq, and, sql, isNull, desc, inArray } from 'drizzle-orm'
 import * as schema from '../db/schema'
 import { participationStatusChangeSchema } from '@shared/validation'
 import { PARTICIPATION_TRANSITIONS } from '@shared/constants'
@@ -46,7 +46,7 @@ applications.get('/', async (c) => {
   const waPerfs = await db.select().from(schema.waPerformance)
   const waPerfMap = new Map(waPerfs.map(wp => [`${wp.athleteId}-${wp.eventId}`, wp]))
 
-  let results = rows.map((r) => ({
+  const baseResults = rows.map((r) => ({
     ...r.application,
     athlete: {
       ...r.athlete,
@@ -57,6 +57,33 @@ applications.get('/', async (c) => {
       catalog: r.catalog,
     },
     waPerformance: waPerfMap.get(`${r.application.athleteId}-${r.application.eventId}`) ?? null,
+  }))
+
+  // Fetch latest agreement totalCost per athlete
+  const athleteIds = [...new Set(baseResults.map((r) => r.athlete.id))]
+  const latestOfferCostMap = new Map<string, number>()
+  if (athleteIds.length > 0) {
+    const agreements = await db
+      .select({
+        athleteId: schema.agreement.athleteId,
+        version: schema.agreement.version,
+        totalCost: schema.agreement.totalCost,
+      })
+      .from(schema.agreement)
+      .where(inArray(schema.agreement.athleteId, athleteIds))
+    const latestVersionMap = new Map<string, number>()
+    for (const agr of agreements) {
+      const existingVersion = latestVersionMap.get(agr.athleteId) ?? -1
+      if (agr.version > existingVersion) {
+        latestVersionMap.set(agr.athleteId, agr.version)
+        latestOfferCostMap.set(agr.athleteId, agr.totalCost)
+      }
+    }
+  }
+
+  let results = baseResults.map((r) => ({
+    ...r,
+    latestOfferCost: latestOfferCostMap.get(r.athlete.id) ?? null,
   }))
 
   // Filter by managerId (athlete.managerId)

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -251,6 +251,7 @@
     "eap": "EAP",
     "meetRecord": "Meet record",
     "assignedSelector": "Assigned selector",
+    "cost": "Cost",
     "estimatedCost": "Estimated cost",
     "estimatedCostLabel": "Estimated",
     "confirmedCostLabel": "Confirmed",

--- a/src/shared/i18n/fr.json
+++ b/src/shared/i18n/fr.json
@@ -251,6 +251,7 @@
     "eap": "EAP",
     "meetRecord": "Record du meeting",
     "assignedSelector": "Sélectionneur assigné",
+    "cost": "Coût",
     "estimatedCost": "Coût estimé",
     "estimatedCostLabel": "Estimé",
     "confirmedCostLabel": "Confirmé",

--- a/src/web/pages/collaborator/CandidatesPage.tsx
+++ b/src/web/pages/collaborator/CandidatesPage.tsx
@@ -13,6 +13,7 @@ interface ApplicationRow extends Application {
   athlete: Athlete
   event: Event & { catalog: EventCatalog }
   waPerformance: WaPerformance | null
+  latestOfferCost: number | null
 }
 
 interface EventListItem extends Event {
@@ -324,8 +325,10 @@ export default function CandidatesPage() {
         return app.athlete.nationality.toLowerCase()
       case 'negotiationStatus':
         return NEGOTIATION_ORDER[app.athlete.negotiationStatus] ?? 99
-      case 'cost':
-        return app.athlete.estTotal
+      case 'cost': {
+        const hasOffer = ['agreement_sent', 'counter_offer_sent', 'confirmed'].includes(app.athlete.negotiationStatus)
+        return hasOffer && app.latestOfferCost != null ? app.latestOfferCost : app.athlete.estTotal
+      }
       case 'event':
         return app.event.catalog.name.toLowerCase()
       case 'personalBest':
@@ -519,7 +522,7 @@ export default function CandidatesPage() {
                   <Th col="name" label={t('athlete.lastName')} />
                   <Th col="nationality" label={t('athlete.nationality')} />
                   <Th col="negotiationStatus" label={t('selection.negotiation')} />
-                  <Th col="cost" label={t('selection.estimatedCost')} />
+                  <Th col="cost" label={t('selection.cost')} />
                   <Th col="event" label={t('athlete.event')} />
                   <Th col="personalBest" label={t('athlete.personalBest')} />
                   <Th col="seasonBest" label={t('athlete.seasonBest')} />
@@ -588,9 +591,19 @@ export default function CandidatesPage() {
 
                       {/* Cost */}
                       <td className="px-3 py-2.5 font-mono text-xs">
-                        {app.athlete.estTotal > 0
-                          ? `CHF ${app.athlete.estTotal.toLocaleString()}`
-                          : '—'}
+                        {(() => {
+                          const hasOffer = ['agreement_sent', 'counter_offer_sent', 'confirmed'].includes(app.athlete.negotiationStatus)
+                          if (hasOffer && app.latestOfferCost != null) {
+                            return `CHF ${app.latestOfferCost.toLocaleString()}`
+                          }
+                          return app.athlete.estTotal > 0 ? (
+                            <span className="text-gray-400">
+                              CHF {app.athlete.estTotal.toLocaleString()}
+                            </span>
+                          ) : (
+                            <span className="text-gray-400">—</span>
+                          )
+                        })()}
                       </td>
 
                       {/* Event */}


### PR DESCRIPTION
Implémente le ticket #50 : la colonne "Coût" affiche le coût estimé en grisé tant qu'aucune offre n'a été envoyée, et le coût calculé de la dernière offre dès qu'une négociation est en cours ou acceptée.

Closes #50

Generated with [Claude Code](https://claude.ai/code)