### PR TITLE
Preserve candidate selection filters when navigating back from athlete page

### DIFF
--- a/src/web/pages/collaborator/AthletePage.tsx
+++ b/src/web/pages/collaborator/AthletePage.tsx
@@ -904,17 +904,21 @@ export default function AthletePage() {
         <div className="max-w-7xl mx-auto px-6 py-4">
           {/* Top row: navigation + language */}
           <div className="flex items-center justify-between mb-3">
-            <Link
-              to={
-                isCommittee ? '/committee/candidates' :
-                user?.role === 'manager' ? '/manager/portal' :
-                user?.role === 'athlete' ? '/athlete/portal' :
-                '/collaborator/candidates'
-              }
-              className="text-sm text-gray-400 hover:text-gray-600"
-            >
-              ← {t('common.back')}
-            </Link>
+            {(isCommittee || user?.role === 'collaborator') ? (
+              <button
+                onClick={() => navigate(-1)}
+                className="text-sm text-gray-400 hover:text-gray-600"
+              >
+                ← {t('common.back')}
+              </button>
+            ) : (
+              <Link
+                to={user?.role === 'manager' ? '/manager/portal' : '/athlete/portal'}
+                className="text-sm text-gray-400 hover:text-gray-600"
+              >
+                ← {t('common.back')}
+              </Link>
+            )}
             <LanguageSwitcher />
           </div>
 

--- a/src/web/pages/collaborator/CandidatesPage.tsx
+++ b/src/web/pages/collaborator/CandidatesPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { api } from '@web/lib/api'
 import { useAuth } from '@web/lib/auth'
@@ -255,32 +255,70 @@ export default function CandidatesPage() {
   const { t } = useTranslation()
   const { user } = useAuth()
   const queryClient = useQueryClient()
-
-  const [eventFilter, setEventFilter] = useState('')
-  const [statusFilters, setStatusFilters] = useState<Set<NegotiationStatus>>(DEFAULT_STATUSES)
-  const [managerFilter, setManagerFilter] = useState('')
-  const [search, setSearch] = useState('')
-  const [sortCol, setSortCol] = useState<SortCol>('name')
-  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc')
+  const [searchParams, setSearchParams] = useSearchParams()
   const [statusModal, setStatusModal] = useState<StatusModal | null>(null)
 
+  // Filter state derived from URL search params
+  const eventFilter = searchParams.get('event') ?? ''
+  const managerFilter = searchParams.get('manager') ?? ''
+  const search = searchParams.get('search') ?? ''
+  const sortCol = (searchParams.get('sort') as SortCol) ?? 'name'
+  const sortDir = (searchParams.get('dir') as 'asc' | 'desc') ?? 'asc'
+  const statusFilters = useMemo(() => {
+    const raw = searchParams.get('statuses')
+    if (!raw) return DEFAULT_STATUSES
+    return new Set(raw.split(',') as NegotiationStatus[])
+  }, [searchParams])
+
+  const updateParam = (key: string, value: string) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        if (value) next.set(key, value)
+        else next.delete(key)
+        return next
+      },
+      { replace: true }
+    )
+  }
+
   const toggleStatus = (s: NegotiationStatus) => {
-    setStatusFilters((prev) => {
-      const next = new Set(prev)
-      if (next.has(s)) next.delete(s)
-      else next.add(s)
-      return next
-    })
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        const raw = prev.get('statuses')
+        const current = new Set(
+          raw ? (raw.split(',') as NegotiationStatus[]) : [...DEFAULT_STATUSES]
+        )
+        if (current.has(s)) current.delete(s)
+        else current.add(s)
+        const arr = [...current]
+        next.set('statuses', arr.join(','))
+        return next
+      },
+      { replace: true }
+    )
   }
 
   const handleSort = (col: SortCol) => {
-    if (sortCol === col) {
-      setSortDir((prev) => (prev === 'asc' ? 'desc' : 'asc'))
-    } else {
-      setSortCol(col)
-      setSortDir('asc')
-    }
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        if ((prev.get('sort') ?? 'name') === col) {
+          next.set('dir', (prev.get('dir') ?? 'asc') === 'asc' ? 'desc' : 'asc')
+        } else {
+          next.set('sort', col)
+          next.delete('dir')
+        }
+        return next
+      },
+      { replace: true }
+    )
   }
+
+  const setEventFilter = (v: string) => updateParam('event', v)
+  const setManagerFilter = (v: string) => updateParam('manager', v)
+  const setSearch = (v: string) => updateParam('search', v)
 
   const { data: applications = [], isLoading } = useQuery<ApplicationRow[]>({
     queryKey: ['applications', eventFilter, managerFilter],


### PR DESCRIPTION
Fixes #52

- CandidatesPage now stores all filter state in URL search params (event, manager, search, statuses, sort) so filters are preserved in navigation history
- AthletePage Back button for collaborator/committee roles uses navigate(-1) to return to the exact CandidatesPage URL with active filters

Generated with [Claude Code](https://claude.ai/code)