### PR TITLE
Decompose AthletePage into focused modules

### DIFF
--- a/src/web/pages/collaborator/AthletePage.tsx
+++ b/src/web/pages/collaborator/AthletePage.tsx
@@ -1,688 +1,38 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { formatAgreementTerms } from '@shared/agreementFormatter'
 import { Link, useParams, useNavigate } from 'react-router-dom'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { api } from '@web/lib/api'
 import { useAuth } from '@web/lib/auth'
 import { LanguageSwitcher } from '@web/App'
-import { NEGOTIATION_TRANSITIONS, COMMITTEE_EXTRA_TRANSITIONS, ATHLETE_TRANSITIONS, NIGHT_LABELS, DINNER_LABELS } from '@shared/constants'
-import { STATUS_COLORS, formatPerf, inputCls, labelCls } from '@web/lib/ui-constants'
-import { computeScore } from '@shared/scoring'
-import type {
-  NegotiationStatus,
-  Agreement,
-  Interaction,
-  Hotel,
-  HotelRoom,
-  Event,
-  EventCatalog,
-  Athlete,
-  Application,
-  WaPerformance,
-  AthleteDetail,
-  ApplicationForAthlete,
-  EditionCosts,
-} from '@shared/types'
-
-interface HotelWithRooms extends Hotel {
-  rooms: HotelRoom[]
-}
-
-type AgreementFormDraft = {
-  appearanceFee: number | ''
-  otherCompensation: number | ''
-  otherCompensationDesc: string
-  transport: number | ''
-  transportAirportHotel: boolean
-  transportHotelStadium: boolean
-  hotelRoomId: string
-  hotelNightTue: boolean
-  hotelNightWed: boolean
-  hotelNightThu: boolean
-  hotelNightFri: boolean
-  hotelNightSat: boolean
-  hotelNightSun: boolean
-  dinnerTue: boolean
-  dinnerWed: boolean
-  dinnerThu: boolean
-  dinnerFri: boolean
-  dinnerSat: boolean
-  dinnerSun: boolean
-  stadiumMeals: boolean
-  notes: string
-}
-
-interface StaffUser {
-  id: string
-  firstName: string
-  lastName: string
-  role: string
-}
-
-interface ApplicationRow extends Application {
-  athlete: Athlete
-  event: Event & { catalog: EventCatalog }
-  waPerformance: WaPerformance | null
-}
-
-// ── Agreement form defaults ──────────────────────────────────────────────────
-
-function defaultAgreement(existing?: Agreement): AgreementFormDraft {
-  if (existing) {
-    return {
-      appearanceFee: existing.appearanceFee,
-      otherCompensation: existing.otherCompensation,
-      otherCompensationDesc: existing.otherCompensationDesc ?? '',
-      transport: existing.transport,
-      transportAirportHotel: existing.transportAirportHotel,
-      transportHotelStadium: existing.transportHotelStadium,
-      hotelRoomId: existing.hotelRoomId ?? '',
-      hotelNightTue: existing.hotelNightTue,
-      hotelNightWed: existing.hotelNightWed,
-      hotelNightThu: existing.hotelNightThu,
-      hotelNightFri: existing.hotelNightFri,
-      hotelNightSat: existing.hotelNightSat,
-      hotelNightSun: existing.hotelNightSun,
-      dinnerTue: existing.dinnerTue,
-      dinnerWed: existing.dinnerWed,
-      dinnerThu: existing.dinnerThu,
-      dinnerFri: existing.dinnerFri,
-      dinnerSat: existing.dinnerSat,
-      dinnerSun: existing.dinnerSun,
-      stadiumMeals: existing.stadiumMeals,
-      notes: existing.notes ?? '',
-    }
-  }
-  return {
-    appearanceFee: '',
-    otherCompensation: '',
-    otherCompensationDesc: '',
-    transport: '',
-    transportAirportHotel: true,
-    transportHotelStadium: true,
-    hotelRoomId: '',
-    hotelNightTue: false,
-    hotelNightWed: false,
-    hotelNightThu: true,
-    hotelNightFri: true,
-    hotelNightSat: true,
-    hotelNightSun: false,
-    dinnerTue: false,
-    dinnerWed: false,
-    dinnerThu: true,
-    dinnerFri: true,
-    dinnerSat: true,
-    dinnerSun: false,
-    stadiumMeals: true,
-    notes: '',
-  }
-}
-
-// ── Sub-components ───────────────────────────────────────────────────────────
-
-function CollapsibleSection({ title, isOpen, onToggle, canEdit, isEditing, onToggleEdit, children }: {
-  title: string; isOpen: boolean; onToggle: () => void
-  canEdit?: boolean; isEditing?: boolean; onToggleEdit?: () => void
-  children: React.ReactNode
-}) {
-  const { t } = useTranslation()
-  return (
-    <div className="bg-white rounded-lg border">
-      <button onClick={onToggle} className="w-full flex items-center justify-between p-3 text-sm font-semibold hover:bg-gray-50">
-        <span>{title}</span>
-        <span className="flex items-center gap-2">
-          {canEdit && isOpen && (
-            <span
-              onClick={e => { e.stopPropagation(); onToggleEdit?.() }}
-              className={`text-xs cursor-pointer px-1.5 py-0.5 rounded ${isEditing ? 'text-blue-600 bg-blue-50' : 'text-gray-400 hover:text-gray-600'}`}
-              title={isEditing ? t('common.cancelEdit') : t('common.edit')}
-            >
-              ✎
-            </span>
-          )}
-          <span className="text-gray-400 text-xs">{isOpen ? '▾' : '▸'}</span>
-        </span>
-      </button>
-      {isOpen && <div className="px-4 pb-4">{children}</div>}
-    </div>
-  )
-}
-
-interface FieldDef {
-  key: string
-  label: string
-  type: 'text' | 'number' | 'date' | 'select' | 'checkbox' | 'textarea'
-  options?: { value: string; label: string }[]
-}
-
-function FieldReadOnly({ athlete, fields, t }: {
-  athlete: Athlete; fields: FieldDef[]; t: (key: string) => string
-}) {
-  return (
-    <div className="space-y-1.5">
-      {fields.map(f => {
-        const raw = (athlete as unknown as Record<string, unknown>)[f.key]
-        let display: string
-        if (f.type === 'checkbox') {
-          display = raw ? t('common.yes') : t('common.no')
-        } else if (f.type === 'select') {
-          display = f.options?.find(o => o.value === raw)?.label ?? String(raw ?? '—')
-        } else {
-          display = raw != null && raw !== '' && raw !== 0 ? String(raw) : '—'
-        }
-        return (
-          <div key={f.key} className="flex justify-between text-xs">
-            <span className="text-gray-500">{f.label}</span>
-            <span className="text-gray-900 font-medium text-right max-w-[60%] truncate">{display}</span>
-          </div>
-        )
-      })}
-    </div>
-  )
-}
-
-function AthleteFieldEditor({ athlete, fields, onSave, isPending, error, t }: {
-  athlete: Athlete
-  fields: FieldDef[]
-  onSave: (data: Record<string, unknown>) => void
-  isPending: boolean
-  error: Error | null
-  t: (key: string) => string
-}) {
-  const [form, setForm] = useState<Record<string, unknown>>(() => {
-    const init: Record<string, unknown> = {}
-    for (const f of fields) {
-      init[f.key] = (athlete as unknown as Record<string, unknown>)[f.key] ?? (f.type === 'checkbox' ? false : f.type === 'number' ? 0 : '')
-    }
-    return init
-  })
-
-  return (
-    <div className="space-y-2">
-      {fields.map(f => (
-        <div key={f.key}>
-          {f.type === 'checkbox' ? (
-            <label className="flex items-center gap-2 text-xs cursor-pointer">
-              <input type="checkbox" checked={form[f.key] as boolean}
-                onChange={e => setForm(p => ({ ...p, [f.key]: e.target.checked }))} />
-              {f.label}
-            </label>
-          ) : f.type === 'select' ? (
-            <>
-              <label className="block text-xs font-medium text-gray-500 mb-1">{f.label}</label>
-              <select className={inputCls} value={form[f.key] as string}
-                onChange={e => setForm(p => ({ ...p, [f.key]: e.target.value }))}>
-                {f.options?.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-              </select>
-            </>
-          ) : f.type === 'textarea' ? (
-            <>
-              <label className="block text-xs font-medium text-gray-500 mb-1">{f.label}</label>
-              <textarea className={inputCls} rows={2} value={form[f.key] as string}
-                onChange={e => setForm(p => ({ ...p, [f.key]: e.target.value }))} />
-            </>
-          ) : (
-            <>
-              <label className="block text-xs font-medium text-gray-500 mb-1">{f.label}</label>
-              <input type={f.type} className={inputCls} value={form[f.key] as string | number}
-                onChange={e => setForm(p => ({ ...p, [f.key]: f.type === 'number' ? (parseInt(e.target.value) || 0) : e.target.value }))} />
-            </>
-          )}
-        </div>
-      ))}
-      <button
-        onClick={() => onSave(form)}
-        disabled={isPending}
-        className="mt-2 text-xs bg-gray-900 text-white px-3 py-1 rounded hover:bg-gray-800 disabled:opacity-50"
-      >
-        {t('common.save')}
-      </button>
-      {error && <p className="text-xs text-red-600">{error.message || t('common.error')}</p>}
-    </div>
-  )
-}
-
-function SelectorAssign({ currentValue, staffUsers, onSave, isPending, t }: {
-  currentValue: string | null
-  staffUsers: StaffUser[]
-  onSave: (val: string) => void
-  isPending: boolean
-  t: (key: string) => string
-}) {
-  const [value, setValue] = useState(currentValue ?? '')
-  return (
-    <div className="space-y-2">
-      <select
-        className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-900"
-        value={value}
-        onChange={e => setValue(e.target.value)}
-      >
-        <option value="">— {t('common.unassigned')} —</option>
-        {staffUsers.map(u => (
-          <option key={u.id} value={u.id}>{u.firstName} {u.lastName}</option>
-        ))}
-      </select>
-      <button
-        onClick={() => onSave(value)}
-        disabled={isPending}
-        className="text-xs bg-gray-900 text-white px-3 py-1 rounded hover:bg-gray-800 disabled:opacity-50"
-      >
-        {t('common.save')}
-      </button>
-    </div>
-  )
-}
-
-function AgreementCard({
-  agreement: c,
-  selectedEventNames,
-  meetingName,
-  lang,
-  isStaff,
-  t,
-}: {
-  agreement: Agreement
-  selectedEventNames: string[]
-  meetingName: string
-  lang: string
-  isStaff: boolean
-  t: (key: string) => string
-}) {
-  const formattedLang = (lang === 'fr' ? 'fr' : 'en') as 'en' | 'fr'
-  const formattedText = formatAgreementTerms(c, selectedEventNames, meetingName, formattedLang)
-
-  return (
-    <div className="p-3 rounded border border-blue-200 bg-blue-50 text-xs">
-      <pre className="whitespace-pre-wrap font-sans text-gray-700 leading-relaxed">{formattedText}</pre>
-      {isStaff && c.totalCost > 0 && (
-        <div className="mt-2 pt-2 border-t border-blue-200 font-semibold text-gray-900">
-          {t('contract.totalCost')}: CHF {c.totalCost.toLocaleString()}
-        </div>
-      )}
-    </div>
-  )
-}
-
-function CounterOfferCard({ interaction }: { interaction: Interaction }) {
-  return (
-    <div className="p-3 rounded border border-rose-200 bg-rose-50 text-xs">
-      <div className="flex justify-between mb-1">
-        <span className="font-semibold text-rose-700">{interaction.authorName}</span>
-        <span className="text-gray-500">{new Date(interaction.createdAt).toLocaleDateString()}</span>
-      </div>
-      <p className="text-gray-700 whitespace-pre-wrap">{interaction.content}</p>
-    </div>
-  )
-}
-
-function InteractionCard({ interaction, onViewEmail }: { interaction: Interaction; onViewEmail?: (emailLogId: string) => void }) {
-  const { t } = useTranslation()
-  const typeIcons: Record<string, string> = {
-    status_change: '●',
-    agreement: '■',
-    counter_offer: '◆',
-    note: '✎',
-    call: '☎',
-    email: '✉',
-  }
-
-  const typeColors: Record<string, string> = {
-    status_change: 'text-blue-500',
-    agreement: 'text-green-500',
-    counter_offer: 'text-purple-500',
-    note: 'text-gray-500',
-    call: 'text-orange-500',
-    email: 'text-indigo-500',
-  }
-
-  const hasEmail = !!interaction.emailLogId
-  const clickable = hasEmail && onViewEmail
-
-  return (
-    <div
-      className={`flex gap-2 ${clickable ? 'cursor-pointer hover:bg-gray-50 rounded p-1 -m-1' : ''}`}
-      onClick={clickable ? () => onViewEmail(interaction.emailLogId!) : undefined}
-    >
-      <span className={`${typeColors[interaction.type] ?? 'text-gray-400'} mt-0.5 shrink-0`}>
-        {typeIcons[interaction.type] ?? '●'}
-      </span>
-      <div className="flex-1 min-w-0">
-        <p className="text-xs text-gray-900">
-          {interaction.content}
-          {hasEmail && <span className="ml-1 text-indigo-500" title={t('common.viewEmail')}>✉</span>}
-        </p>
-        <p className="text-[10px] text-gray-400 mt-0.5">
-          {interaction.authorName} — {new Date(interaction.createdAt).toLocaleString()}
-        </p>
-      </div>
-    </div>
-  )
-}
-
-// ── Scoring popup (hover over score) ─────────────────────────────────────────
-
-function ScoringPopup({ app, athlete, edition, t }: {
-  app: ApplicationForAthlete
-  athlete: AthleteDetail
-  edition: EditionCosts
-  t: (key: string, opts?: Record<string, unknown>) => string
-}) {
-  const wp = app.waPerformance
-  if (!wp || wp.personalBest == null || !edition) return null
-
-  const perfType = app.event.catalog.discipline === 'Course' ? 'MIN' as const : 'MAX' as const
-
-  const breakdown = computeScore({
-    personalBest: wp.personalBest ?? 0,
-    seasonBest: wp.seasonBest ?? 0,
-    worldRanking: wp.worldRanking ?? 100,
-    estimatedCostTotal: athlete.estTotal ?? 0,
-    isEap: athlete.isEap,
-    isSwiss: athlete.isSwiss,
-    perfType,
-    intMinima: app.event.intMinima,
-    swissMinima: app.event.swissMinima,
-    eapMinima: app.event.eapMinima,
-  }, edition)
-
-  return (
-    <div className="absolute z-20 left-0 top-6 bg-white border rounded-lg shadow-lg p-3 text-xs w-52">
-      <p className="font-semibold mb-2">{t('selection.scoringBreakdown')}</p>
-      <div className="space-y-1 text-gray-600">
-        <div className="flex justify-between">
-          <span>PB ({edition.weightPB}%)</span>
-          <span className="font-mono">{(breakdown.f1PB * 100).toFixed(1)}</span>
-        </div>
-        <div className="flex justify-between">
-          <span>SB ({edition.weightSB}%)</span>
-          <span className="font-mono">{(breakdown.f2SB * 100).toFixed(1)}</span>
-        </div>
-        <div className="flex justify-between">
-          <span>Ranking ({edition.weightRanking}%)</span>
-          <span className="font-mono">{(breakdown.f3Ranking * 100).toFixed(1)}</span>
-        </div>
-        <div className="flex justify-between">
-          <span>Cost ({edition.weightCost}%)</span>
-          <span className="font-mono">{(breakdown.f4Cost * 100).toFixed(1)}</span>
-        </div>
-        {breakdown.eapBonus > 0 && (
-          <div className="flex justify-between">
-            <span>EAP bonus (+{edition.bonusEap}%)</span>
-            <span className="font-mono">+{(breakdown.eapBonus * 100).toFixed(1)}</span>
-          </div>
-        )}
-        <div className="border-t pt-1 mt-1 flex justify-between font-semibold text-gray-900">
-          <span>Total</span>
-          <span className="font-mono">{(breakdown.finalScore * 100).toFixed(0)}</span>
-        </div>
-        <div className="text-[10px] text-gray-400">
-          {breakdown.eligible ? t('selection.eligible') : t('selection.notEligible')}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-// ── Confirmed athletes popup (hover over event name) ──────────────────────────
-
-function ConfirmedAthletesPopup({ eventId, t }: {
-  eventId: string
-  t: (key: string) => string
-}) {
-  const { data: confirmed = [], isLoading } = useQuery<ApplicationRow[]>({
-    queryKey: ['confirmed-athletes', eventId],
-    queryFn: () => api.get(`/api/v1/applications?eventId=${eventId}&negotiationStatus=confirmed`),
-    staleTime: 60_000,
-  })
-
-  return (
-    <div className="absolute z-20 left-0 top-6 bg-white border rounded-lg shadow-lg p-3 text-xs w-56">
-      <p className="font-semibold mb-2">{t('selection.confirmedAthletes')}</p>
-      {isLoading ? (
-        <p className="text-gray-400">{t('common.loading')}</p>
-      ) : confirmed.length === 0 ? (
-        <p className="text-gray-400">{t('selection.noConfirmedAthletes')}</p>
-      ) : (
-        <div className="space-y-1">
-          {[...confirmed]
-            .sort((a, b) => {
-              const sb1 = a.waPerformance?.seasonBest ?? a.seasonBest ?? null
-              const sb2 = b.waPerformance?.seasonBest ?? b.seasonBest ?? null
-              if (sb1 == null && sb2 == null) return 0
-              if (sb1 == null) return 1
-              if (sb2 == null) return -1
-              return sb2 - sb1
-            })
-            .map(a => (
-              <div key={a.id} className="flex justify-between text-gray-700">
-                <span>{a.athlete.lastName}, {a.athlete.firstName}</span>
-                <span className="font-mono text-gray-500">
-                  {formatPerf(a.waPerformance?.seasonBest ?? a.seasonBest ?? null)}
-                </span>
-              </div>
-            ))}
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ── SB color helper ──────────────────────────────────────────────────────────
-
-function sbColorClass(sb: number | null, app: ApplicationForAthlete, athlete: AthleteDetail): string {
-  if (sb == null) return ''
-  const perfType = app.event.catalog.discipline === 'Course' ? 'MIN' : 'MAX'
-  const minima = [app.event.intMinima]
-  if (athlete.isSwiss) minima.push(app.event.swissMinima)
-  if (athlete.isEap && app.event.eapMinima != null) minima.push(app.event.eapMinima)
-
-  const meetsSome = minima.some(m => perfType === 'MIN' ? sb <= m : sb >= m)
-  return meetsSome ? 'text-green-600' : 'text-red-600'
-}
-
-// ── Banner event row ─────────────────────────────────────────────────────────
-
-function BannerEventRow({ app, athlete, edition, isStaff, onParticipationChange, onRescore, onWaPerfSave, isPendingParticipation, t }: {
-  app: ApplicationForAthlete
-  athlete: AthleteDetail
-  edition: EditionCosts | null
-  isStaff: boolean
-  onParticipationChange: (appId: string, status: string) => void
-  onRescore: (appId: string) => void
-  onWaPerfSave: (athleteId: string, eventId: string, data: { personalBest?: number; seasonBest?: number; worldRanking?: number }) => void
-  isPendingParticipation: boolean
-  t: (key: string) => string
-}) {
-  const [showEventPopup, setShowEventPopup] = useState(false)
-  const [showScorePopup, setShowScorePopup] = useState(false)
-  const [editingPerf, setEditingPerf] = useState(false)
-  const [perfForm, setPerfForm] = useState({
-    personalBest: app.waPerformance?.personalBest != null ? String(app.waPerformance.personalBest) : '',
-    seasonBest: app.waPerformance?.seasonBest != null ? String(app.waPerformance.seasonBest) : '',
-    worldRanking: app.waPerformance?.worldRanking != null ? String(app.waPerformance.worldRanking) : '',
-  })
-
-  const wp = app.waPerformance
-  const pb = wp?.personalBest ?? app.personalBest
-  const sb = wp?.seasonBest ?? app.seasonBest
-  const wr = wp?.worldRanking ?? app.worldRanking
-
-  const PARTICIPATION_COLORS: Record<string, string> = {
-    pending: 'bg-yellow-100 text-yellow-800',
-    selected: 'bg-green-100 text-green-800',
-    not_selected: 'bg-red-100 text-red-800',
-  }
-
-  return (
-    <div className="flex items-center gap-3 py-1.5 border-b border-gray-100 last:border-0">
-      {/* Event name with hover popup */}
-      <div className="relative shrink-0 w-28">
-        <button
-          onMouseEnter={() => setShowEventPopup(true)}
-          onMouseLeave={() => setShowEventPopup(false)}
-          className="font-medium text-sm text-gray-900 hover:text-blue-700 text-left truncate block w-full"
-        >
-          {app.event.catalog.name}
-        </button>
-        {showEventPopup && <ConfirmedAthletesPopup eventId={app.eventId} t={t} />}
-      </div>
-
-      {/* PB / SB (colored) / Ranking */}
-      {editingPerf ? (
-        <div className="flex gap-1 items-center flex-1">
-          <input type="number" step="0.01" placeholder="PB" className="w-20 px-1 py-0.5 border border-gray-300 rounded text-xs" value={perfForm.personalBest}
-            onChange={e => setPerfForm(p => ({ ...p, personalBest: e.target.value }))} />
-          <input type="number" step="0.01" placeholder="SB" className="w-20 px-1 py-0.5 border border-gray-300 rounded text-xs" value={perfForm.seasonBest}
-            onChange={e => setPerfForm(p => ({ ...p, seasonBest: e.target.value }))} />
-          <input type="number" placeholder="#" className="w-16 px-1 py-0.5 border border-gray-300 rounded text-xs" value={perfForm.worldRanking}
-            onChange={e => setPerfForm(p => ({ ...p, worldRanking: e.target.value }))} />
-          <button onClick={() => {
-            onWaPerfSave(athlete.id, app.eventId, {
-              ...(perfForm.personalBest ? { personalBest: parseFloat(perfForm.personalBest) } : {}),
-              ...(perfForm.seasonBest ? { seasonBest: parseFloat(perfForm.seasonBest) } : {}),
-              ...(perfForm.worldRanking ? { worldRanking: parseInt(perfForm.worldRanking) } : {}),
-            })
-            setEditingPerf(false)
-          }} className="text-[10px] text-green-600 hover:text-green-800">✓</button>
-          <button onClick={() => setEditingPerf(false)} className="text-[10px] text-gray-400 hover:text-gray-600">✕</button>
-        </div>
-      ) : (
-        <div className="flex items-center gap-3 text-xs text-gray-600 flex-1">
-          <span>PB: <span className="font-mono font-medium">{formatPerf(pb)}</span></span>
-          <span>SB: <span className={`font-mono font-medium ${sbColorClass(sb, app, athlete)}`}>{formatPerf(sb)}</span></span>
-          <span>#{wr ?? '—'}</span>
-
-          {/* Score with popup */}
-          {app.score != null && (
-            <div className="relative">
-              <button
-                onMouseEnter={() => setShowScorePopup(true)}
-                onMouseLeave={() => setShowScorePopup(false)}
-                className="font-mono font-bold text-sm text-gray-900 hover:text-blue-700"
-              >
-                {(app.score * 100).toFixed(0)}
-              </button>
-              {showScorePopup && edition && (
-                <ScoringPopup app={app} athlete={athlete} edition={edition} t={t} />
-              )}
-            </div>
-          )}
-
-          {/* Recommendation */}
-          {app.recommendation && (
-            <span className={`text-[10px] px-1.5 py-0.5 rounded ${
-              app.recommendation === 'Highly Recommended' ? 'bg-green-100 text-green-700' :
-              app.recommendation === 'Recommended' ? 'bg-blue-100 text-blue-700' :
-              app.recommendation === 'Under Review' ? 'bg-yellow-100 text-yellow-700' :
-              'bg-red-100 text-red-700'
-            }`}>
-              {app.recommendation}
-            </span>
-          )}
-        </div>
-      )}
-
-      {/* Participation status — staff gets buttons (locked when athlete is confirmed), others get read-only badge */}
-      <div className="flex gap-1 shrink-0 items-center">
-        {isStaff && athlete.negotiationStatus !== 'confirmed' ? (
-          <>
-            {(['pending', 'selected', 'not_selected'] as const).map((status) => (
-              <button
-                key={status}
-                onClick={() => {
-                  if (app.participationStatus !== status) {
-                    onParticipationChange(app.id, status)
-                  }
-                }}
-                disabled={isPendingParticipation || app.participationStatus === status}
-                className={`text-[10px] px-2 py-0.5 rounded font-medium border ${
-                  app.participationStatus === status
-                    ? PARTICIPATION_COLORS[status] ?? 'bg-gray-100 text-gray-500'
-                    : 'border-gray-200 text-gray-400 hover:bg-gray-50'
-                }`}
-              >
-                {t(`participation.${status}`)}
-              </button>
-            ))}
-          </>
-        ) : (
-          <>
-            <span className={`text-[10px] px-2 py-0.5 rounded font-medium ${PARTICIPATION_COLORS[app.participationStatus] ?? 'bg-gray-100 text-gray-500'}`}>
-              {t(`participation.${app.participationStatus}`)}
-            </span>
-            {isStaff && athlete.negotiationStatus === 'confirmed' && (
-              <span className="text-[10px] text-gray-400" title={t('participation.lockedConfirmed')}>🔒</span>
-            )}
-          </>
-        )}
-      </div>
-
-      {/* Staff-only: edit perf + rescore */}
-      {isStaff && !editingPerf && (
-        <div className="flex gap-1 shrink-0">
-          <button onClick={() => setEditingPerf(true)} className="text-[10px] text-blue-600 hover:text-blue-800">
-            {t('selection.editPerformance')}
-          </button>
-          <button onClick={() => onRescore(app.id)} className="text-[10px] text-gray-400 hover:text-gray-600">
-            {t('selection.rescore')}
-          </button>
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ── Cost hover popup ─────────────────────────────────────────────────────────
-
-function CostPopup({ athlete, latestAgreement, costMode, t }: {
-  athlete: AthleteDetail
-  latestAgreement: Agreement | undefined
-  costMode: string
-  t: (key: string) => string
-}) {
-  return (
-    <div className="absolute z-20 right-0 top-6 bg-white border rounded-lg shadow-lg p-3 text-xs w-56">
-      {costMode === 'confirmed' && !latestAgreement ? (
-        <p className="text-green-700 italic">{t('selection.acceptedAtMeeting')}</p>
-      ) : costMode !== 'estimated' && latestAgreement ? (
-        <div className="space-y-1 text-gray-600">
-          {latestAgreement.appearanceFee > 0 && <div className="flex justify-between"><span>{t('contract.bonus')}</span><span>CHF {latestAgreement.appearanceFee}</span></div>}
-          {latestAgreement.transport > 0 && <div className="flex justify-between"><span>{t('contract.transport')}</span><span>CHF {latestAgreement.transport}</span></div>}
-          {latestAgreement.otherCompensation > 0 && <div className="flex justify-between"><span>{t('contract.otherCompensation')}</span><span>CHF {latestAgreement.otherCompensation}</span></div>}
-          <div className="border-t pt-1 mt-1 flex justify-between font-semibold text-gray-900">
-            <span>{t('contract.totalCost')}</span>
-            <span>CHF {(latestAgreement.totalCost ?? 0).toLocaleString()}</span>
-          </div>
-          <div className="text-[10px] text-gray-400">v{latestAgreement.version} — {new Date(latestAgreement.sentAt).toLocaleDateString()}</div>
-        </div>
-      ) : (
-        <div className="space-y-1 text-gray-600">
-          <div className="flex justify-between"><span>{t('collaborator.estTravel')}</span><span>CHF {athlete.estTravel}</span></div>
-          <div className="flex justify-between"><span>{t('collaborator.estAccommodation')}</span><span>CHF {athlete.estAccommodation}</span></div>
-          <div className="flex justify-between"><span>{t('collaborator.estAppearance')}</span><span>CHF {athlete.estAppearance}</span></div>
-          <div className="border-t pt-1 mt-1 flex justify-between font-semibold text-gray-900">
-            <span>{t('contract.totalCost')}</span>
-            <span>CHF {(athlete.estTotal ?? 0).toLocaleString()}</span>
-          </div>
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ── Main page ────────────────────────────────────────────────────────────────
+import { NEGOTIATION_TRANSITIONS, COMMITTEE_EXTRA_TRANSITIONS, ATHLETE_TRANSITIONS } from '@shared/constants'
+import { STATUS_COLORS } from '@web/lib/ui-constants'
+import type { NegotiationStatus } from '@shared/types'
+import { defaultAgreement } from './athlete/types'
+import type { AgreementFormDraft } from './athlete/types'
+import { useAthleteData, useAthleteMutations, useEmailQuery } from './athlete/useAthleteData'
+import { BannerEventRow, CostPopup } from './athlete/BannerEventRow'
+import { PersonalTab } from './athlete/PersonalTab'
+import { NegotiationTab } from './athlete/NegotiationTab'
+import {
+  ConfirmTransitionDialog,
+  EmailPreviewModal,
+  EmailPopupModal,
+  CounterOfferModal,
+  MessageModal,
+  AgreementFormModal,
+} from './athlete/modals'
 
 export default function AthletePage() {
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
   const { id } = useParams<{ id: string }>()
   const { user } = useAuth()
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
 
+  // ── Data ───────────────────────────────���──────────────────────────────
+  const { athlete, isLoading, staffUsers, allRooms } = useAthleteData(id)
+  const mutations = useAthleteMutations(id)
+
+  // ── UI state ───────────────��──────────────────────────────────────────
   const [activeTab, setActiveTab] = useState<'personal' | 'negotiation'>('negotiation')
-  const [openSection, setOpenSection] = useState<string | null>('identity')
-  const [editingSection, setEditingSection] = useState<string | null>(null)
   const [confirmDialog, setConfirmDialog] = useState<{
     fromStatus: NegotiationStatus
     toStatus: NegotiationStatus
@@ -692,8 +42,6 @@ export default function AthletePage() {
   const [showAgreementForm, setShowAgreementForm] = useState(false)
   const [noteType, setNoteType] = useState<'note' | 'call' | 'email'>('note')
   const [noteContent, setNoteContent] = useState('')
-  const [internalNotes, setInternalNotes] = useState('')
-  const [notesInitialized, setNotesInitialized] = useState(false)
   const [agreementForm, setAgreementForm] = useState<AgreementFormDraft>(() => defaultAgreement())
   const [showCostPopup, setShowCostPopup] = useState(false)
   const [showCounterOfferModal, setShowCounterOfferModal] = useState(false)
@@ -701,150 +49,29 @@ export default function AthletePage() {
   const [showMessageModal, setShowMessageModal] = useState(false)
   const [messageText, setMessageText] = useState('')
   const [viewingEmailId, setViewingEmailId] = useState<string | null>(null)
+  const [agreementInitialized, setAgreementInitialized] = useState(false)
 
-  const { data: athlete, isLoading } = useQuery<AthleteDetail>({
-    queryKey: ['athlete', id],
-    queryFn: () => api.get(`/api/v1/athletes/${id}`),
-    enabled: !!id,
-  })
+  const { data: viewingEmail } = useEmailQuery(viewingEmailId)
 
-  const { data: hotels = [] } = useQuery<HotelWithRooms[]>({
-    queryKey: ['hotels'],
-    queryFn: () => api.get('/api/v1/hotels'),
-  })
-
-  const { data: staffUsers = [] } = useQuery<StaffUser[]>({
-    queryKey: ['staff-users'],
-    queryFn: () => api.get('/api/v1/users?role=collaborator,committee'),
-  })
-
-  // Email popup query — only fetches when an email is being viewed
-  const { data: viewingEmail } = useQuery<{ subject: string; body: string; htmlBody?: string; to: string; sentAt: string }>({
-    queryKey: ['email', viewingEmailId],
-    queryFn: () => api.get(`/api/v1/emails/${viewingEmailId}`),
-    enabled: !!viewingEmailId,
-  })
-
-  const allRooms = hotels.flatMap(h => h.rooms.map(r => ({ ...r, hotelName: h.name })))
-
+  // Initialize agreement form from latest agreement once
   const latestAgreement = athlete?.agreements?.length
     ? athlete.agreements[athlete.agreements.length - 1]
     : undefined
 
-  if (athlete && !notesInitialized) {
-    setInternalNotes(athlete.internalNotes ?? '')
+  if (athlete && !agreementInitialized) {
     if (latestAgreement) {
       setAgreementForm(defaultAgreement(latestAgreement))
     }
-    setNotesInitialized(true)
+    setAgreementInitialized(true)
   }
 
-  // ── Mutations ──────────────────────────────────────────────────────────────
+  // Propagate email preview from mutations
+  const handleStatusSuccess = (data: { emailPreview?: { subject: string; body: string } } | undefined) => {
+    setConfirmDialog(null)
+    if (data?.emailPreview) setEmailPreview(data.emailPreview)
+  }
 
-  const statusMutation = useMutation({
-    mutationFn: (status: NegotiationStatus) =>
-      api.patch<{ emailPreview?: { subject: string; body: string } }>(`/api/v1/athletes/${id}/negotiation-status`, { status }),
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['athlete', id] })
-      setConfirmDialog(null)
-      if (data?.emailPreview) setEmailPreview(data.emailPreview)
-    },
-  })
-
-  const agreementMutation = useMutation({
-    mutationFn: (data: AgreementFormDraft) =>
-      api.post<{ emailPreview?: { subject: string; body: string } }>(`/api/v1/athletes/${id}/agreements`, {
-        ...data,
-        appearanceFee: data.appearanceFee === '' ? 0 : data.appearanceFee,
-        otherCompensation: data.otherCompensation === '' ? 0 : data.otherCompensation,
-        transport: data.transport === '' ? 0 : data.transport,
-        hotelRoomId: data.hotelRoomId || undefined,
-      }),
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['athlete', id] })
-      setShowAgreementForm(false)
-      if (data?.emailPreview) setEmailPreview(data.emailPreview)
-    },
-  })
-
-  const noteMutation = useMutation({
-    mutationFn: (data: { type: string; content: string }) =>
-      api.post(`/api/v1/athletes/${id}/interactions`, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['athlete', id] })
-      setNoteContent('')
-    },
-  })
-
-  const internalNotesMutation = useMutation({
-    mutationFn: (notes: string) =>
-      api.patch(`/api/v1/athletes/${id}`, { internalNotes: notes }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['athlete', id] }),
-  })
-
-  const participationMutation = useMutation({
-    mutationFn: ({ appId, status }: { appId: string; status: string }) =>
-      api.patch(`/api/v1/applications/${appId}/participation-status`, { participationStatus: status }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['athlete', id] }),
-  })
-
-  const scoreMutation = useMutation({
-    mutationFn: (appId: string) => api.post(`/api/v1/applications/${appId}/score`, {}),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['athlete', id] }),
-  })
-
-  const athleteUpdateMutation = useMutation({
-    mutationFn: (data: Record<string, unknown>) =>
-      api.patch(`/api/v1/athletes/${id}`, data),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['athlete', id] }),
-  })
-
-  const waPerfMutation = useMutation({
-    mutationFn: (data: { athleteId: string; eventId: string; personalBest?: number; seasonBest?: number; worldRanking?: number }) =>
-      api.post('/api/v1/wa-performance', data),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['athlete', id] }),
-  })
-
-  const waFetchMutation = useMutation({
-    mutationFn: () => api.post<{ fetched: number; matched: number; errors: string[] }>(`/api/v1/wa-performance/fetch/${id}`),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['athlete', id] }),
-  })
-
-  const counterOfferMutation = useMutation({
-    mutationFn: async (text: string) => {
-      await api.post(`/api/v1/athletes/${id}/interactions`, { type: 'counter_offer', content: text })
-      return api.patch<{ emailPreview?: { subject: string; body: string } }>(`/api/v1/athletes/${id}/negotiation-status`, { status: 'counter_offer_sent' })
-    },
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['athlete', id] })
-      setShowCounterOfferModal(false)
-      setCounterOfferText('')
-      if (data?.emailPreview) setEmailPreview(data.emailPreview)
-    },
-  })
-
-  const freeMessageMutation = useMutation({
-    mutationFn: (text: string) =>
-      api.post(`/api/v1/athletes/${id}/interactions`, { type: 'note', content: text }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['athlete', id] })
-      setShowMessageModal(false)
-      setMessageText('')
-    },
-  })
-
-  const archiveMutation = useMutation({
-    mutationFn: () => api.delete(`/api/v1/athletes/${id}`),
-    onSuccess: () => navigate(
-      user?.role === 'committee' ? '/committee/candidates' :
-      user?.role === 'manager' ? '/manager/portal' :
-      user?.role === 'athlete' ? '/athlete/portal' :
-      '/collaborator/candidates'
-    ),
-  })
-
-  // ── Render ─────────────────────────────────────────────────────────────────
-
+  // ── Loading ─────────────────��─────────────────────────────────────────
   if (isLoading || !athlete) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50 text-gray-400 text-sm">
@@ -853,6 +80,7 @@ export default function AthletePage() {
     )
   }
 
+  // ── Derived state ─────���──────────────────────��────────────────────────
   const isStaff = user?.role === 'collaborator' || user?.role === 'committee'
   const isCommittee = user?.role === 'committee'
   const isAthleteOrManager = user?.role === 'athlete' || user?.role === 'manager'
@@ -872,8 +100,6 @@ export default function AthletePage() {
   const hasAtLeastOneSelected = athlete.applications.some(a => a.participationStatus === 'selected')
   const canSendAgreement = allDecided && hasAtLeastOneSelected
 
-  const toggleSection = (name: string) => setOpenSection(openSection === name ? null : name)
-
   const costMode =
     currentStatus === 'confirmed' ? 'confirmed' :
     ['agreement_sent', 'counter_offer_sent'].includes(currentStatus) ? 'negotiating' :
@@ -886,7 +112,6 @@ export default function AthletePage() {
     return !base.includes(status) && extra.includes(status)
   }
 
-  // Cost summary text for banner (estTotal and totalCost are undefined for athlete/manager roles)
   const costSummary = (() => {
     if (costMode === 'confirmed' && athlete.agreements.length === 0) return t('selection.acceptedAtMeeting')
     if (costMode !== 'estimated' && latestAgreement) return latestAgreement.totalCost != null ? `CHF ${latestAgreement.totalCost.toLocaleString()}` : ''
@@ -899,7 +124,7 @@ export default function AthletePage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* ── Banner ──────────────────────────────────────────────────────── */}
+      {/* ── Banner ────��─────────────────────────────────────────────────── */}
       <div className="bg-white border-b">
         <div className="max-w-7xl mx-auto px-6 py-4">
           {/* Top row: navigation + language */}
@@ -965,17 +190,16 @@ export default function AthletePage() {
                     </a>
                     {isStaff && (
                       <button
-                        onClick={() => waFetchMutation.mutate()}
-                        disabled={waFetchMutation.isPending}
+                        onClick={() => mutations.waFetchMutation.mutate()}
+                        disabled={mutations.waFetchMutation.isPending}
                         className="text-xs text-blue-600 hover:text-blue-800 disabled:opacity-50"
                         title={t('wa.fetch')}
                       >
-                        {waFetchMutation.isPending ? t('wa.fetching') : '↻ WA'}
+                        {mutations.waFetchMutation.isPending ? t('wa.fetching') : '↻ WA'}
                       </button>
                     )}
                   </>
                 )}
-                {/* Cost summary — staff only */}
                 {isStaff && (
                   <div className="relative ml-auto">
                     <button
@@ -999,16 +223,11 @@ export default function AthletePage() {
 
             {/* Action buttons */}
             <div className="flex flex-wrap gap-2 justify-end shrink-0">
-
-              {/* Staff: Send Agreement button (to_review and counter_offer_sent) */}
               {isStaff && (currentStatus === 'to_review' || currentStatus === 'counter_offer_sent') && (
                 <button
-                  onClick={() => {
-                    setActiveTab('negotiation')
-                    setShowAgreementForm(true)
-                  }}
+                  onClick={() => { setActiveTab('negotiation'); setShowAgreementForm(true) }}
                   disabled={!canSendAgreement}
-                  title={!canSendAgreement ? (allDecided ? t('selection.decideAllFirst') : t('selection.decideAllFirst')) : undefined}
+                  title={!canSendAgreement ? t('selection.decideAllFirst') : undefined}
                   className={`text-xs px-3 py-1.5 rounded font-medium border ${
                     canSendAgreement
                       ? 'bg-blue-600 text-white border-blue-600 hover:bg-blue-700'
@@ -1019,15 +238,12 @@ export default function AthletePage() {
                 </button>
               )}
 
-              {/* Staff: awaiting athlete/manager response during agreement_sent */}
               {isStaff && currentStatus === 'agreement_sent' && (
                 <span className="text-xs text-gray-500 italic py-1.5">{t('action.awaitingResponse')}</span>
               )}
 
-              {/* All role-based direct status transitions */}
               {allowedTransitions.map((toStatus) => {
                 const committeeOnly = isCommitteeOnly(toStatus as NegotiationStatus)
-
                 const buttonLabel = isAthleteOrManager
                   ? toStatus === 'confirmed' ? t('action.accept')
                     : toStatus === 'counter_offer_sent' ? t('action.sendCounterOffer')
@@ -1048,11 +264,13 @@ export default function AthletePage() {
                         setConfirmDialog({
                           fromStatus: currentStatus,
                           toStatus: toStatus as NegotiationStatus,
-                          onConfirm: () => statusMutation.mutate(toStatus as NegotiationStatus),
+                          onConfirm: () => mutations.statusMutation.mutate(toStatus as NegotiationStatus, {
+                            onSuccess: handleStatusSuccess,
+                          }),
                         })
                       }
                     }}
-                    disabled={statusMutation.isPending}
+                    disabled={mutations.statusMutation.isPending}
                     className={`text-xs px-3 py-1.5 rounded font-medium border ${
                       toStatus === 'confirmed'
                         ? 'bg-green-600 text-white border-green-600 hover:bg-green-700'
@@ -1074,7 +292,6 @@ export default function AthletePage() {
                 )
               })}
 
-              {/* Send message — always visible for all roles, all statuses */}
               <button
                 onClick={() => setShowMessageModal(true)}
                 className="text-xs px-3 py-1.5 rounded font-medium border border-gray-300 bg-white text-gray-600 hover:bg-gray-50"
@@ -1088,83 +305,49 @@ export default function AthletePage() {
             </div>
           </div>
 
-          {statusMutation.isError && (
-            <p className="text-xs text-red-600 mt-2">{(statusMutation.error as Error)?.message || t('common.error')}</p>
+          {mutations.statusMutation.isError && (
+            <p className="text-xs text-red-600 mt-2">{(mutations.statusMutation.error as Error)?.message || t('common.error')}</p>
           )}
 
-          {/* Counter-offer modal — free text for athlete/manager */}
           {showCounterOfferModal && (
-            <div className="mt-3 p-4 rounded border border-purple-300 bg-purple-50">
-              <h3 className="text-sm font-semibold text-gray-900 mb-2">{t('action.counterOffer')}</h3>
-              <textarea
-                className="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-purple-500"
-                rows={4}
-                placeholder={t('action.counterOfferPlaceholder')}
-                value={counterOfferText}
-                onChange={e => setCounterOfferText(e.target.value)}
-              />
-              <div className="flex gap-2 mt-2">
-                <button
-                  onClick={() => {
-                    if (counterOfferText.trim()) {
-                      counterOfferMutation.mutate(counterOfferText)
-                    }
-                  }}
-                  disabled={counterOfferMutation.isPending || !counterOfferText.trim()}
-                  className="text-xs px-3 py-1.5 rounded font-medium bg-purple-600 text-white hover:bg-purple-700 disabled:opacity-50"
-                >
-                  {counterOfferMutation.isPending ? t('common.loading') : t('common.submit')}
-                </button>
-                <button
-                  onClick={() => { setShowCounterOfferModal(false); setCounterOfferText('') }}
-                  className="text-xs px-3 py-1.5 rounded border border-gray-300 hover:bg-gray-50"
-                >
-                  {t('common.cancel')}
-                </button>
-              </div>
-              {counterOfferMutation.isError && (
-                <p className="text-xs text-red-600 mt-1">{(counterOfferMutation.error as Error)?.message || t('common.error')}</p>
-              )}
-            </div>
+            <CounterOfferModal
+              text={counterOfferText}
+              onTextChange={setCounterOfferText}
+              onSubmit={() => {
+                if (counterOfferText.trim()) {
+                  mutations.counterOfferMutation.mutate(counterOfferText, {
+                    onSuccess: (data) => {
+                      setShowCounterOfferModal(false)
+                      setCounterOfferText('')
+                      if (data?.emailPreview) setEmailPreview(data.emailPreview)
+                    },
+                  })
+                }
+              }}
+              onCancel={() => { setShowCounterOfferModal(false); setCounterOfferText('') }}
+              isPending={mutations.counterOfferMutation.isPending}
+              error={mutations.counterOfferMutation.error}
+            />
           )}
 
-          {/* Send message modal — always available */}
           {showMessageModal && (
-            <div className="mt-3 p-4 rounded border border-gray-300 bg-gray-50">
-              <h3 className="text-sm font-semibold text-gray-900 mb-2">{t('action.sendMessage')}</h3>
-              <textarea
-                className="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-500"
-                rows={3}
-                placeholder={t('action.messagePlaceholder')}
-                value={messageText}
-                onChange={e => setMessageText(e.target.value)}
-              />
-              <div className="flex gap-2 mt-2">
-                <button
-                  onClick={() => {
-                    if (messageText.trim()) {
-                      freeMessageMutation.mutate(messageText)
-                    }
-                  }}
-                  disabled={freeMessageMutation.isPending || !messageText.trim()}
-                  className="text-xs px-3 py-1.5 rounded font-medium bg-gray-900 text-white hover:bg-gray-800 disabled:opacity-50"
-                >
-                  {freeMessageMutation.isPending ? t('common.loading') : t('common.submit')}
-                </button>
-                <button
-                  onClick={() => { setShowMessageModal(false); setMessageText('') }}
-                  className="text-xs px-3 py-1.5 rounded border border-gray-300 hover:bg-gray-50"
-                >
-                  {t('common.cancel')}
-                </button>
-              </div>
-              {freeMessageMutation.isError && (
-                <p className="text-xs text-red-600 mt-1">{(freeMessageMutation.error as Error)?.message || t('common.error')}</p>
-              )}
-            </div>
+            <MessageModal
+              text={messageText}
+              onTextChange={setMessageText}
+              onSubmit={() => {
+                if (messageText.trim()) {
+                  mutations.freeMessageMutation.mutate(messageText, {
+                    onSuccess: () => { setShowMessageModal(false); setMessageText('') },
+                  })
+                }
+              }}
+              onCancel={() => { setShowMessageModal(false); setMessageText('') }}
+              isPending={mutations.freeMessageMutation.isPending}
+              error={mutations.freeMessageMutation.error}
+            />
           )}
 
-          {/* Events in banner — per spec */}
+          {/* Events in banner */}
           {athlete.applications.length > 0 && (
             <div className="mt-4 border-t pt-3">
               <div className="text-xs font-semibold text-gray-500 mb-1">{t('selection.participation')}</div>
@@ -1176,13 +359,13 @@ export default function AthletePage() {
                   edition={athlete.edition}
                   isStaff={!!isStaff}
                   onParticipationChange={(appId, status) =>
-                    participationMutation.mutate({ appId, status })
+                    mutations.participationMutation.mutate({ appId, status })
                   }
-                  onRescore={(appId) => scoreMutation.mutate(appId)}
+                  onRescore={(appId) => mutations.scoreMutation.mutate(appId)}
                   onWaPerfSave={(athleteId, eventId, data) =>
-                    waPerfMutation.mutate({ athleteId, eventId, ...data })
+                    mutations.waPerfMutation.mutate({ athleteId, eventId, ...data })
                   }
-                  isPendingParticipation={participationMutation.isPending}
+                  isPendingParticipation={mutations.participationMutation.isPending}
                   t={t}
                 />
               ))}
@@ -1208,320 +391,43 @@ export default function AthletePage() {
         </div>
       </div>
 
-      {/* ── Tab content ──────────────────────────────────────────────────── */}
+      {/* ── Tab content ────────────��─────────────────────────���───────────── */}
       <div className="max-w-7xl mx-auto px-6 py-6">
+        {activeTab === 'personal' && (
+          <PersonalTab
+            athlete={athlete}
+            isStaff={!!isStaff}
+            isAthleteOrManager={isAthleteOrManager}
+            staffUsers={staffUsers}
+            mutations={{
+              athleteUpdate: mutations.athleteUpdateMutation,
+              internalNotes: mutations.internalNotesMutation,
+            }}
+          />
+        )}
 
-        {/* ── Tab 1: Personal Data ──────────────────────────────────────── */}
-        {activeTab === 'personal' && (() => {
-          // Field definitions for each section
-          const identityFields: FieldDef[] = [
-            { key: 'firstName', label: t('athlete.firstName'), type: 'text' },
-            { key: 'lastName', label: t('athlete.lastName'), type: 'text' },
-            { key: 'dateOfBirth', label: t('athlete.dateOfBirth'), type: 'date' },
-            { key: 'nationality', label: t('athlete.nationality'), type: 'text' },
-            { key: 'gender', label: t('athlete.gender'), type: 'select', options: [
-              { value: 'M', label: t('athlete.male') }, { value: 'F', label: t('athlete.female') }
-            ]},
-            { key: 'federation', label: t('athlete.federation'), type: 'text' },
-            { key: 'club', label: t('athlete.club'), type: 'text' },
-            { key: 'athleteEmail', label: t('athlete.email'), type: 'text' },
-            { key: 'athletePhone', label: t('athlete.phone'), type: 'text' },
-            { key: 'waProfileUrl', label: t('athlete.waProfile'), type: 'text' },
-            { key: 'swiLicence', label: t('athlete.swissLicence'), type: 'text' },
-            { key: 'honours', label: t('athlete.honours'), type: 'text' },
-            { key: 'distanceFromGva', label: t('athlete.distanceFromGva'), type: 'number' },
-            { key: 'isEap', label: t('athlete.eapMember'), type: 'checkbox' },
-            { key: 'isSwiss', label: t('athlete.swiss'), type: 'checkbox' },
-            { key: 'eapCity', label: t('athlete.eapCity'), type: 'text' },
-          ]
-          // Athletes/managers can only edit contact fields from identity
-          const athleteIdentityFields: FieldDef[] = identityFields.filter(f =>
-            ['athleteEmail', 'athletePhone'].includes(f.key)
-          )
-
-          const complianceFields: FieldDef[] = [
-            { key: 'iRunClean', label: t('compliance.iRunClean'), type: 'select', options: [
-              { value: 'yes', label: t('common.yes') }, { value: 'no', label: t('common.no') },
-              { value: 'in_progress', label: t('common.inProgress') }, { value: 'unknown', label: t('common.unknown') },
-            ]},
-            { key: 'dopingFree', label: t('compliance.dopingFree'), type: 'select', options: [
-              { value: 'yes', label: t('common.yes') }, { value: 'no', label: t('common.no') }, { value: 'unknown', label: t('common.unknown') },
-            ]},
-          ]
-
-          const logisticsFields: FieldDef[] = [
-            { key: 'arrivalDate', label: `${t('logistics.arrival')} ${t('logistics.date')}`, type: 'date' },
-            { key: 'arrivalFlight', label: `${t('logistics.arrival')} ${t('logistics.flightNumber')}`, type: 'text' },
-            { key: 'arrivalFrom', label: `${t('logistics.arrival')} ${t('logistics.from')}`, type: 'text' },
-            { key: 'arrivalTime', label: `${t('logistics.arrival')} ${t('logistics.time')}`, type: 'text' },
-            { key: 'departureDate', label: `${t('logistics.departure')} ${t('logistics.date')}`, type: 'date' },
-            { key: 'departureFlight', label: `${t('logistics.departure')} ${t('logistics.flightNumber')}`, type: 'text' },
-            { key: 'departureTo', label: `${t('logistics.departure')} ${t('logistics.to')}`, type: 'text' },
-            { key: 'departureTime', label: `${t('logistics.departure')} ${t('logistics.time')}`, type: 'text' },
-            { key: 'accommodationReqs', label: t('logistics.specialRequests'), type: 'textarea' },
-          ]
-
-          const costFields: FieldDef[] = [
-            { key: 'estAppearance', label: t('collaborator.estAppearance'), type: 'number' },
-            { key: 'estTravel', label: t('collaborator.estTravel'), type: 'number' },
-            { key: 'estAccommodation', label: t('collaborator.estAccommodation'), type: 'number' },
-            { key: 'estTotal', label: t('selection.estimatedCost'), type: 'number' },
-          ]
-
-          const paymentFields: FieldDef[] = [
-            { key: 'bankIban', label: t('collaborator.iban'), type: 'text' },
-            { key: 'paymentStatus', label: t('collaborator.paymentStatus'), type: 'select', options: [
-              { value: 'pending', label: t('common.pending') }, { value: 'done', label: t('common.done') },
-            ]},
-            { key: 'paymentAmount', label: t('collaborator.paymentAmount'), type: 'number' },
-            { key: 'paymentDate', label: t('collaborator.paymentDate'), type: 'date' },
-            { key: 'paymentMethod', label: t('collaborator.paymentMethod'), type: 'select', options: [
-              { value: '', label: '—' }, { value: 'cash', label: t('collaborator.cash') },
-              { value: 'bank', label: t('collaborator.bank') }, { value: 'western_union', label: t('collaborator.westernUnion') },
-              { value: 'paypal', label: t('collaborator.paypal') }, { value: 'other', label: t('collaborator.other') },
-            ]},
-          ]
-
-          const toggleEdit = (section: string) => setEditingSection(editingSection === section ? null : section)
-
-          // Helper to render a section with view/edit toggle
-          const renderSection = (name: string, title: string, fields: FieldDef[], canEdit: boolean) => (
-            <CollapsibleSection
-              title={title}
-              isOpen={openSection === name}
-              onToggle={() => toggleSection(name)}
-              canEdit={canEdit}
-              isEditing={editingSection === name}
-              onToggleEdit={() => toggleEdit(name)}
-            >
-              {editingSection === name && canEdit ? (
-                <AthleteFieldEditor
-                  athlete={athlete}
-                  fields={fields}
-                  onSave={(data) => { athleteUpdateMutation.mutate(data); setEditingSection(null) }}
-                  isPending={athleteUpdateMutation.isPending}
-                  error={athleteUpdateMutation.error}
-                  t={t}
-                />
-              ) : (
-                <FieldReadOnly athlete={athlete} fields={fields} t={t} />
-              )}
-            </CollapsibleSection>
-          )
-
-          return (
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-4">
-              {/* Identity — staff can edit all, athlete/manager can edit contact only */}
-              {isStaff
-                ? renderSection('identity', t('collaborator.identity'), identityFields, true)
-                : (
-                  <>
-                    <CollapsibleSection title={t('collaborator.identity')} isOpen={openSection === 'identity'} onToggle={() => toggleSection('identity')}>
-                      <FieldReadOnly athlete={athlete} fields={identityFields.filter(f => !['athleteEmail', 'athletePhone'].includes(f.key))} t={t} />
-                    </CollapsibleSection>
-                    {renderSection('contact', t('athlete.contact'), athleteIdentityFields, true)}
-                  </>
+        {activeTab === 'negotiation' && (
+          <NegotiationTab
+            athlete={athlete}
+            isStaff={!!isStaff}
+            isAthleteOrManager={isAthleteOrManager}
+            canSendAgreement={canSendAgreement}
+            onShowAgreementForm={() => setShowAgreementForm(true)}
+            noteType={noteType}
+            onNoteTypeChange={setNoteType}
+            noteContent={noteContent}
+            onNoteContentChange={setNoteContent}
+            onAddNote={() => {
+              if (noteContent.trim()) {
+                mutations.noteMutation.mutate(
+                  { type: isAthleteOrManager ? 'note' : noteType, content: noteContent },
+                  { onSuccess: () => setNoteContent('') },
                 )
               }
-
-              {/* Compliance — editable by all */}
-              {renderSection('compliance', t('compliance.title'), complianceFields, true)}
-
-              {/* Logistics — editable by all */}
-              {renderSection('logistics', t('logistics.title'), logisticsFields, true)}
-            </div>
-
-            <div className="space-y-4">
-              {/* Assigned selector — staff only */}
-              {isStaff && (
-                <CollapsibleSection title={t('selection.assignedSelector')} isOpen={openSection === 'selector'} onToggle={() => toggleSection('selector')}>
-                  <SelectorAssign
-                    currentValue={athlete.assignedSelector}
-                    staffUsers={staffUsers}
-                    onSave={(val) => athleteUpdateMutation.mutate({ assignedSelector: val || null })}
-                    isPending={athleteUpdateMutation.isPending}
-                    t={t}
-                  />
-                </CollapsibleSection>
-              )}
-
-              {/* Cost estimates — staff only, read-only (auto-computed) */}
-              {isStaff && renderSection('costs', t('selection.estimatedCost'), costFields, false)}
-
-              {/* Payment — staff only */}
-              {isStaff && renderSection('payment', t('collaborator.payment'), paymentFields, true)}
-
-              {/* Notes */}
-              <CollapsibleSection title={t('common.notes')} isOpen={openSection === 'notes'} onToggle={() => toggleSection('notes')}>
-                <div className="space-y-3">
-                  <div>
-                    <label className="block text-xs font-medium text-gray-500 mb-1">{t('collaborator.participantNotes')}</label>
-                    <p className="text-xs text-gray-600 bg-gray-50 p-2 rounded min-h-[2rem]">{athlete.participantNotes || '—'}</p>
-                  </div>
-                  <div>
-                    <label className="block text-xs font-medium text-gray-500 mb-1">{t('collaborator.additionalNotes')}</label>
-                    <p className="text-xs text-gray-600 bg-gray-50 p-2 rounded min-h-[2rem]">{athlete.additionalNotes || '—'}</p>
-                  </div>
-                  {isStaff && (
-                    <div>
-                      <label className="block text-xs font-medium text-gray-500 mb-1">{t('collaborator.internalNotes')}</label>
-                      <textarea
-                        className={inputCls}
-                        rows={3}
-                        value={internalNotes}
-                        onChange={(e) => setInternalNotes(e.target.value)}
-                      />
-                      <button
-                        onClick={() => internalNotesMutation.mutate(internalNotes)}
-                        disabled={internalNotesMutation.isPending}
-                        className="mt-2 text-xs bg-gray-900 text-white px-3 py-1 rounded hover:bg-gray-800 disabled:opacity-50"
-                      >
-                        {t('common.save')}
-                      </button>
-                    </div>
-                  )}
-                </div>
-              </CollapsibleSection>
-            </div>
-          </div>
-          )
-        })()}
-
-        {/* ── Tab 2: Agreement & Negotiation ───────────────────────────── */}
-        {activeTab === 'negotiation' && (
-          <div className="grid grid-cols-2 gap-6">
-            {/* Left: Agreements */}
-            <div className="space-y-4">
-              {/* Agreement history */}
-              <div className="bg-white rounded-lg border p-4">
-                <div className="flex items-center justify-between mb-3">
-                  <h3 className="font-semibold text-sm">{t('contract.title')}</h3>
-                  {isStaff && (currentStatus === 'to_review' || currentStatus === 'counter_offer_sent') && (
-                    <button
-                      onClick={() => setShowAgreementForm(true)}
-                      disabled={!canSendAgreement}
-                      title={!canSendAgreement ? t('selection.decideAllFirst') : undefined}
-                      className={`text-xs ${canSendAgreement ? 'text-blue-600 hover:text-blue-800' : 'text-gray-300 cursor-not-allowed'}`}
-                    >
-                      {latestAgreement ? t('contract.newVersion') : t('action.sendAgreement')}
-                    </button>
-                  )}
-                </div>
-
-                {(() => {
-                  const selectedEventNames = athlete.applications
-                    .filter(a => a.participationStatus === 'selected')
-                    .map(a => `${a.event.catalog.name} ${a.event.catalog.gender === 'M' ? (i18n.language === 'fr' ? 'Hommes' : 'Men') : (i18n.language === 'fr' ? 'Femmes' : 'Women')}`)
-                  const meetingName = athlete.edition?.name ?? 'Atletica Geneve'
-
-                  type TimelineItem =
-                    | { kind: 'agreement'; id: string; date: string; data: Agreement }
-                    | { kind: 'counter_offer'; id: string; date: string; data: Interaction }
-
-                  const agreementItems: TimelineItem[] = athlete.agreements.map(a => ({
-                    kind: 'agreement' as const,
-                    id: a.id,
-                    date: a.sentAt,
-                    data: a,
-                  }))
-
-                  const counterOfferItems: TimelineItem[] = athlete.interactions
-                    .filter(i => i.type === 'counter_offer')
-                    .map(i => ({
-                      kind: 'counter_offer' as const,
-                      id: i.id,
-                      date: i.createdAt,
-                      data: i,
-                    }))
-
-                  // Normalize both ISO ("2026-04-23T12:00:00.000Z") and SQLite ("2026-04-23 12:00:00") formats
-                  const toMs = (d: string) =>
-                    new Date(d.includes('T') ? d : d.replace(' ', 'T') + 'Z').getTime()
-                  const timelineItems = [...agreementItems, ...counterOfferItems]
-                    .sort((a, b) => toMs(b.date) - toMs(a.date))
-
-                  if (currentStatus === 'confirmed' && timelineItems.length === 0) {
-                    return <p className="text-sm text-green-700 italic">{t('selection.acceptedAtMeeting')}</p>
-                  }
-                  if (timelineItems.length === 0) {
-                    return <p className="text-xs text-gray-400">{t('contract.noOfferYet')}</p>
-                  }
-                  return (
-                    <div className="space-y-3">
-                      {timelineItems.map(item =>
-                        item.kind === 'agreement'
-                          ? (
-                            <AgreementCard
-                              key={item.id}
-                              agreement={item.data}
-                              selectedEventNames={selectedEventNames}
-                              meetingName={meetingName}
-                              lang={i18n.language}
-                              isStaff={!!isStaff}
-                              t={t}
-                            />
-                          )
-                          : <CounterOfferCard key={item.id} interaction={item.data} />
-                      )}
-                    </div>
-                  )
-                })()}
-              </div>
-
-            </div>
-
-            {/* Right: Timeline */}
-            <div className="space-y-4">
-              {/* Add interaction */}
-              <div className="bg-white rounded-lg border p-4">
-                <h3 className="font-semibold text-sm mb-3">{t('collaborator.addNote')}</h3>
-                {isStaff && (
-                  <select
-                    className={`${inputCls} mb-2`}
-                    value={noteType}
-                    onChange={e => setNoteType(e.target.value as typeof noteType)}
-                  >
-                    <option value="note">{t('collaborator.note')}</option>
-                    <option value="call">{t('collaborator.phoneCall')}</option>
-                    <option value="email">{t('athlete.email')}</option>
-                  </select>
-                )}
-                <textarea
-                  className={inputCls}
-                  rows={3}
-                  placeholder={t('collaborator.enterNote')}
-                  value={noteContent}
-                  onChange={e => setNoteContent(e.target.value)}
-                />
-                <button
-                  onClick={() => {
-                    if (noteContent.trim()) {
-                      noteMutation.mutate({ type: isAthleteOrManager ? 'note' : noteType, content: noteContent })
-                    }
-                  }}
-                  disabled={noteMutation.isPending || !noteContent.trim()}
-                  className="mt-2 text-xs bg-gray-900 text-white px-3 py-1.5 rounded hover:bg-gray-800 disabled:opacity-50"
-                >
-                  {t('common.add')}
-                </button>
-              </div>
-
-              {/* Timeline — limited height with scrollbar */}
-              <div className="bg-white rounded-lg border p-4">
-                <h3 className="font-semibold text-sm mb-3">{t('collaborator.timeline')}</h3>
-                {athlete.interactions.length === 0 ? (
-                  <p className="text-xs text-gray-400">{t('collaborator.noInteractions')}</p>
-                ) : (
-                  <div className="space-y-3 max-h-96 overflow-y-auto">
-                    {athlete.interactions.map(interaction => (
-                      <InteractionCard key={interaction.id} interaction={interaction} onViewEmail={setViewingEmailId} />
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
+            }}
+            isNotePending={mutations.noteMutation.isPending}
+            onViewEmail={setViewingEmailId}
+          />
         )}
 
         {/* Archive button — committee only */}
@@ -1530,282 +436,57 @@ export default function AthletePage() {
             <button
               onClick={() => {
                 if (confirm(t('confirm.archiveAthlete', { athlete: `${athlete.firstName} ${athlete.lastName}` }))) {
-                  archiveMutation.mutate()
+                  mutations.archiveMutation.mutate()
                 }
               }}
-              disabled={archiveMutation.isPending}
+              disabled={mutations.archiveMutation.isPending}
               className="text-xs text-red-500 hover:text-red-700 border border-red-200 rounded px-3 py-1.5 hover:bg-red-50 disabled:opacity-50"
             >
               {t('collaborator.archiveAthlete')}
             </button>
-            {archiveMutation.isError && (
-              <p className="text-xs text-red-600 mt-1">{(archiveMutation.error as Error)?.message || t('common.error')}</p>
+            {mutations.archiveMutation.isError && (
+              <p className="text-xs text-red-600 mt-1">{(mutations.archiveMutation.error as Error)?.message || t('common.error')}</p>
             )}
           </div>
         )}
       </div>
 
-      {/* Transition confirmation dialog */}
+      {/* ── Modals ────────���──────────────────────────────────────────────── */}
       {confirmDialog && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={() => setConfirmDialog(null)}>
-          <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 p-6" onClick={e => e.stopPropagation()}>
-            <p className="text-sm text-gray-900 mb-5 leading-relaxed">
-              {t(`confirm.transition.${confirmDialog.fromStatus}__${confirmDialog.toStatus}`, {
-                athlete: `${athlete.firstName} ${athlete.lastName}`,
-                meeting: athlete.edition?.name ?? '',
-              })}
-            </p>
-            <div className="flex gap-2 justify-end">
-              <button
-                onClick={() => setConfirmDialog(null)}
-                className="text-xs px-3 py-1.5 rounded border border-gray-300 hover:bg-gray-50"
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                onClick={() => confirmDialog.onConfirm()}
-                disabled={statusMutation.isPending || agreementMutation.isPending}
-                className={`text-xs px-3 py-1.5 rounded font-medium text-white disabled:opacity-50 ${
-                  confirmDialog.toStatus === 'rejected'
-                    ? 'bg-red-600 hover:bg-red-700'
-                    : confirmDialog.toStatus === 'to_review'
-                    ? 'bg-orange-600 hover:bg-orange-700'
-                    : confirmDialog.toStatus === 'confirmed'
-                    ? 'bg-green-600 hover:bg-green-700'
-                    : confirmDialog.toStatus === 'withdrawn'
-                    ? 'bg-gray-600 hover:bg-gray-700'
-                    : 'bg-blue-600 hover:bg-blue-700'
-                }`}
-              >
-                {t('common.confirm')}
-              </button>
-            </div>
-          </div>
-        </div>
+        <ConfirmTransitionDialog
+          fromStatus={confirmDialog.fromStatus}
+          toStatus={confirmDialog.toStatus}
+          athlete={athlete}
+          onConfirm={confirmDialog.onConfirm}
+          onCancel={() => setConfirmDialog(null)}
+          isPending={mutations.statusMutation.isPending || mutations.agreementMutation.isPending}
+        />
       )}
 
-      {/* Email preview modal — shown after each status transition */}
       {emailPreview && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={() => setEmailPreview(null)}>
-          <div className="bg-white rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[80vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
-            <div className="flex items-center justify-between p-4 border-b">
-              <h3 className="font-semibold text-sm">{t('emailPreview.title')}</h3>
-              <button onClick={() => setEmailPreview(null)} className="text-gray-400 hover:text-gray-600">✕</button>
-            </div>
-            <div className="p-4 text-sm space-y-3">
-              <p className="text-xs text-gray-500">{t('emailPreview.description')}</p>
-              <div className="text-xs text-gray-700">
-                <span className="font-medium">{t('emailPreview.subject')}:</span> {emailPreview.subject}
-              </div>
-              <pre className="text-xs text-gray-700 whitespace-pre-wrap bg-gray-50 p-3 rounded border">{emailPreview.body}</pre>
-              <div className="flex justify-end">
-                <button
-                  onClick={() => setEmailPreview(null)}
-                  className="text-xs px-4 py-1.5 rounded font-medium bg-gray-900 text-white hover:bg-gray-800"
-                >
-                  {t('common.close')}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <EmailPreviewModal emailPreview={emailPreview} onClose={() => setEmailPreview(null)} />
       )}
 
-      {/* Email popup modal */}
       {viewingEmailId && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={() => setViewingEmailId(null)}>
-          <div className="bg-white rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[80vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
-            <div className="flex items-center justify-between p-4 border-b">
-              <h3 className="font-semibold text-sm">{t('collaborator.emailDetail')}</h3>
-              <button onClick={() => setViewingEmailId(null)} className="text-gray-400 hover:text-gray-600">✕</button>
-            </div>
-            {viewingEmail ? (
-              <div className="p-4 text-sm space-y-2">
-                <div className="text-xs text-gray-500">
-                  <span className="font-medium">{t('admin.emailTo')}:</span> {viewingEmail.to}
-                </div>
-                <div className="text-xs text-gray-500">
-                  <span className="font-medium">{t('admin.subject')}:</span> {viewingEmail.subject}
-                </div>
-                <div className="text-xs text-gray-400">
-                  {new Date(viewingEmail.sentAt).toLocaleString()}
-                </div>
-                <div className="border-t pt-3 mt-2">
-                  {viewingEmail.htmlBody ? (
-                    <div className="text-sm prose prose-sm max-w-none" dangerouslySetInnerHTML={{ __html: viewingEmail.htmlBody }} />
-                  ) : (
-                    <pre className="text-xs text-gray-700 whitespace-pre-wrap">{viewingEmail.body}</pre>
-                  )}
-                </div>
-              </div>
-            ) : (
-              <div className="p-4 text-sm text-gray-400">{t('common.loading')}</div>
-            )}
-          </div>
-        </div>
+        <EmailPopupModal email={viewingEmail} onClose={() => setViewingEmailId(null)} />
       )}
 
-      {/* Agreement form popup */}
       {showAgreementForm && isStaff && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={() => setShowAgreementForm(false)}>
-          <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
-            <div className="flex items-center justify-between p-4 border-b">
-              <h3 className="font-semibold text-sm">
-                {t('contract.sendOffer')} — v{(athlete.agreements.length || 0) + 1}
-              </h3>
-              <button onClick={() => setShowAgreementForm(false)} className="text-gray-400 hover:text-gray-600">✕</button>
-            </div>
-            <div className="p-4 space-y-3">
-              <div>
-                <label className={labelCls}>{t('contract.bonus')} (CHF)</label>
-                <input
-                  type="number"
-                  className={`${inputCls} text-right`}
-                  value={agreementForm.appearanceFee}
-                  placeholder="0"
-                  onChange={e => setAgreementForm(p => ({ ...p, appearanceFee: e.target.value === '' ? '' : (parseInt(e.target.value) || 0) }))}
-                />
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className={labelCls}>{t('contract.otherCompensation')} (CHF)</label>
-                  <input
-                    type="number"
-                    className={`${inputCls} text-right`}
-                    value={agreementForm.otherCompensation}
-                    placeholder="0"
-                    onChange={e => setAgreementForm(p => ({ ...p, otherCompensation: e.target.value === '' ? '' : (parseInt(e.target.value) || 0) }))}
-                  />
-                </div>
-                <div>
-                  <label className={labelCls}>{t('contract.description')}</label>
-                  <input
-                    className={inputCls}
-                    value={agreementForm.otherCompensationDesc}
-                    onChange={e => setAgreementForm(p => ({ ...p, otherCompensationDesc: e.target.value }))}
-                    placeholder={t('contract.otherCompensationDesc')}
-                  />
-                </div>
-              </div>
-              <div>
-                <label className={labelCls}>{t('contract.transport')} (CHF)</label>
-                <input
-                  type="number"
-                  className={`${inputCls} text-right`}
-                  value={agreementForm.transport}
-                  placeholder="0"
-                  onChange={e => setAgreementForm(p => ({ ...p, transport: e.target.value === '' ? '' : (parseInt(e.target.value) || 0) }))}
-                />
-              </div>
-              <div className="flex items-center gap-4">
-                <label className="flex items-center gap-2 text-sm cursor-pointer">
-                  <input type="checkbox" checked={agreementForm.transportAirportHotel}
-                    onChange={e => setAgreementForm(p => ({ ...p, transportAirportHotel: e.target.checked }))} />
-                  {t('contract.transportAirportHotel')}
-                </label>
-                <label className="flex items-center gap-2 text-sm cursor-pointer">
-                  <input type="checkbox" checked={agreementForm.transportHotelStadium}
-                    onChange={e => setAgreementForm(p => ({ ...p, transportHotelStadium: e.target.checked }))} />
-                  {t('contract.transportHotelStadium')}
-                </label>
-              </div>
-              <div>
-                <label className={labelCls}>{t('logistics.hotel')}</label>
-                <select className={inputCls} value={agreementForm.hotelRoomId}
-                  onChange={e => setAgreementForm(p => ({ ...p, hotelRoomId: e.target.value }))}>
-                  <option value="">— {t('contract.noHotelRoom')} —</option>
-                  {allRooms.map(r => (
-                    <option key={r.id} value={r.id}>{r.hotelName} — {r.roomType} (CHF {r.costPerNight}/night)</option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label className={labelCls}>{t('contract.hotelNights')}</label>
-                <div className="flex gap-2">
-                  {NIGHT_LABELS.map(night => {
-                    const key = `hotelNight${night.charAt(0).toUpperCase() + night.slice(1)}` as keyof AgreementFormDraft
-                    return (
-                      <label key={night} className={`flex flex-col items-center text-xs cursor-pointer px-2 py-1 rounded border ${
-                        agreementForm[key] ? 'bg-gray-900 text-white border-gray-900' : 'border-gray-300'
-                      }`}>
-                        <input type="checkbox" className="sr-only" checked={agreementForm[key] as boolean}
-                          onChange={e => setAgreementForm(p => ({ ...p, [key]: e.target.checked }))} />
-                        {t(`night.${night}`)}
-                      </label>
-                    )
-                  })}
-                </div>
-              </div>
-              <div>
-                <label className={labelCls}>{t('contract.dinners')}</label>
-                <div className="flex gap-2">
-                  {DINNER_LABELS.map(day => {
-                    const key = `dinner${day.charAt(0).toUpperCase() + day.slice(1)}` as keyof AgreementFormDraft
-                    return (
-                      <label key={day} className={`flex flex-col items-center text-xs cursor-pointer px-2 py-1 rounded border ${
-                        agreementForm[key] ? 'bg-gray-900 text-white border-gray-900' : 'border-gray-300'
-                      }`}>
-                        <input type="checkbox" className="sr-only" checked={agreementForm[key] as boolean}
-                          onChange={e => setAgreementForm(p => ({ ...p, [key]: e.target.checked }))} />
-                        {t(`night.${day}`)}
-                      </label>
-                    )
-                  })}
-                </div>
-              </div>
-              <label className="flex items-center gap-2 text-sm cursor-pointer">
-                <input type="checkbox" checked={agreementForm.stadiumMeals}
-                  onChange={e => setAgreementForm(p => ({ ...p, stadiumMeals: e.target.checked }))} />
-                {t('contract.stadiumMeals')}
-              </label>
-              <div>
-                <label className={labelCls}>{t('contract.notesToAthlete')}</label>
-                <textarea className={inputCls} rows={2} value={agreementForm.notes}
-                  onChange={e => setAgreementForm(p => ({ ...p, notes: e.target.value }))} />
-              </div>
-
-              {/* Live cost preview */}
-              {(() => {
-                const room = allRooms.find(r => r.id === agreementForm.hotelRoomId)
-                const nights = NIGHT_LABELS.filter(n => agreementForm[`hotelNight${n.charAt(0).toUpperCase() + n.slice(1)}` as keyof AgreementFormDraft]).length
-                const dinners = DINNER_LABELS.filter(d => agreementForm[`dinner${d.charAt(0).toUpperCase() + d.slice(1)}` as keyof AgreementFormDraft]).length
-                let total = (agreementForm.appearanceFee || 0) + (agreementForm.otherCompensation || 0) + (agreementForm.transport || 0)
-                total += nights * (room?.costPerNight ?? 0)
-                total += dinners * (room?.dinnerCost ?? 0)
-                if (agreementForm.stadiumMeals) total += athlete.edition?.stadiumMealCost ?? 0
-                if (agreementForm.transportAirportHotel) total += athlete.edition?.transportAirportHotelCost ?? 0
-                if (agreementForm.transportHotelStadium) total += athlete.edition?.transportHotelStadiumCost ?? 0
-                return (
-                  <div className="bg-gray-50 rounded p-3 text-sm">
-                    <div className="flex justify-between font-semibold">
-                      <span>{t('contract.totalCost')}</span>
-                      <span>CHF {total.toLocaleString()}</span>
-                    </div>
-                  </div>
-                )
-              })()}
-
-              <div className="flex gap-2 justify-end pt-2 border-t">
-                <button
-                  onClick={() => setShowAgreementForm(false)}
-                  className="px-4 py-2 text-sm border rounded hover:bg-gray-50"
-                >
-                  {t('common.cancel')}
-                </button>
-                <button
-                  onClick={() => agreementMutation.mutate(agreementForm)}
-                  disabled={agreementMutation.isPending}
-                  className="px-6 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 font-medium"
-                >
-                  {agreementMutation.isPending ? t('common.loading') : t('contract.validate')}
-                </button>
-              </div>
-              {agreementMutation.isError && (
-                <p className="text-xs text-red-600">{(agreementMutation.error as Error)?.message || t('common.error')}</p>
-              )}
-            </div>
-          </div>
-        </div>
+        <AgreementFormModal
+          form={agreementForm}
+          onChange={setAgreementForm}
+          allRooms={allRooms}
+          athlete={athlete}
+          onSubmit={() => mutations.agreementMutation.mutate(agreementForm, {
+            onSuccess: (data) => {
+              setShowAgreementForm(false)
+              if (data?.emailPreview) setEmailPreview(data.emailPreview)
+            },
+          })}
+          onClose={() => setShowAgreementForm(false)}
+          isPending={mutations.agreementMutation.isPending}
+          error={mutations.agreementMutation.error}
+        />
       )}
     </div>
   )

--- a/src/web/pages/collaborator/athlete/BannerEventRow.tsx
+++ b/src/web/pages/collaborator/athlete/BannerEventRow.tsx
@@ -1,0 +1,318 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { api } from '@web/lib/api'
+import { computeScore } from '@shared/scoring'
+import { formatPerf } from '@web/lib/ui-constants'
+import type { AthleteDetail, ApplicationForAthlete, EditionCosts, Agreement } from '@shared/types'
+import type { ApplicationRow } from './types'
+
+// ── ScoringPopup ────────────────────────────────────────────────────────────
+
+function ScoringPopup({ app, athlete, edition, t }: {
+  app: ApplicationForAthlete
+  athlete: AthleteDetail
+  edition: EditionCosts
+  t: (key: string, opts?: Record<string, unknown>) => string
+}) {
+  const wp = app.waPerformance
+  if (!wp || wp.personalBest == null || !edition) return null
+
+  const perfType = app.event.catalog.discipline === 'Course' ? 'MIN' as const : 'MAX' as const
+
+  const breakdown = computeScore({
+    personalBest: wp.personalBest ?? 0,
+    seasonBest: wp.seasonBest ?? 0,
+    worldRanking: wp.worldRanking ?? 100,
+    estimatedCostTotal: athlete.estTotal ?? 0,
+    isEap: athlete.isEap,
+    isSwiss: athlete.isSwiss,
+    perfType,
+    intMinima: app.event.intMinima,
+    swissMinima: app.event.swissMinima,
+    eapMinima: app.event.eapMinima,
+  }, edition)
+
+  return (
+    <div className="absolute z-20 left-0 top-6 bg-white border rounded-lg shadow-lg p-3 text-xs w-52">
+      <p className="font-semibold mb-2">{t('selection.scoringBreakdown')}</p>
+      <div className="space-y-1 text-gray-600">
+        <div className="flex justify-between">
+          <span>PB ({edition.weightPB}%)</span>
+          <span className="font-mono">{(breakdown.f1PB * 100).toFixed(1)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>SB ({edition.weightSB}%)</span>
+          <span className="font-mono">{(breakdown.f2SB * 100).toFixed(1)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Ranking ({edition.weightRanking}%)</span>
+          <span className="font-mono">{(breakdown.f3Ranking * 100).toFixed(1)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Cost ({edition.weightCost}%)</span>
+          <span className="font-mono">{(breakdown.f4Cost * 100).toFixed(1)}</span>
+        </div>
+        {breakdown.eapBonus > 0 && (
+          <div className="flex justify-between">
+            <span>EAP bonus (+{edition.bonusEap}%)</span>
+            <span className="font-mono">+{(breakdown.eapBonus * 100).toFixed(1)}</span>
+          </div>
+        )}
+        <div className="border-t pt-1 mt-1 flex justify-between font-semibold text-gray-900">
+          <span>Total</span>
+          <span className="font-mono">{(breakdown.finalScore * 100).toFixed(0)}</span>
+        </div>
+        <div className="text-[10px] text-gray-400">
+          {breakdown.eligible ? t('selection.eligible') : t('selection.notEligible')}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── ConfirmedAthletesPopup ──────────────────────────────────────────────────
+
+function ConfirmedAthletesPopup({ eventId, t }: {
+  eventId: string
+  t: (key: string) => string
+}) {
+  const { data: confirmed = [], isLoading } = useQuery<ApplicationRow[]>({
+    queryKey: ['confirmed-athletes', eventId],
+    queryFn: () => api.get(`/api/v1/applications?eventId=${eventId}&negotiationStatus=confirmed`),
+    staleTime: 60_000,
+  })
+
+  return (
+    <div className="absolute z-20 left-0 top-6 bg-white border rounded-lg shadow-lg p-3 text-xs w-56">
+      <p className="font-semibold mb-2">{t('selection.confirmedAthletes')}</p>
+      {isLoading ? (
+        <p className="text-gray-400">{t('common.loading')}</p>
+      ) : confirmed.length === 0 ? (
+        <p className="text-gray-400">{t('selection.noConfirmedAthletes')}</p>
+      ) : (
+        <div className="space-y-1">
+          {[...confirmed]
+            .sort((a, b) => {
+              const sb1 = a.waPerformance?.seasonBest ?? a.seasonBest ?? null
+              const sb2 = b.waPerformance?.seasonBest ?? b.seasonBest ?? null
+              if (sb1 == null && sb2 == null) return 0
+              if (sb1 == null) return 1
+              if (sb2 == null) return -1
+              return sb2 - sb1
+            })
+            .map(a => (
+              <div key={a.id} className="flex justify-between text-gray-700">
+                <span>{a.athlete.lastName}, {a.athlete.firstName}</span>
+                <span className="font-mono text-gray-500">
+                  {formatPerf(a.waPerformance?.seasonBest ?? a.seasonBest ?? null)}
+                </span>
+              </div>
+            ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── SB color helper ─────────────────────────────────────────────────────────
+
+function sbColorClass(sb: number | null, app: ApplicationForAthlete, athlete: AthleteDetail): string {
+  if (sb == null) return ''
+  const perfType = app.event.catalog.discipline === 'Course' ? 'MIN' : 'MAX'
+  const minima = [app.event.intMinima]
+  if (athlete.isSwiss) minima.push(app.event.swissMinima)
+  if (athlete.isEap && app.event.eapMinima != null) minima.push(app.event.eapMinima)
+
+  const meetsSome = minima.some(m => perfType === 'MIN' ? sb <= m : sb >= m)
+  return meetsSome ? 'text-green-600' : 'text-red-600'
+}
+
+// ── BannerEventRow ──────────────────────────────────────────────────────────
+
+export function BannerEventRow({ app, athlete, edition, isStaff, onParticipationChange, onRescore, onWaPerfSave, isPendingParticipation, t }: {
+  app: ApplicationForAthlete
+  athlete: AthleteDetail
+  edition: EditionCosts | null
+  isStaff: boolean
+  onParticipationChange: (appId: string, status: string) => void
+  onRescore: (appId: string) => void
+  onWaPerfSave: (athleteId: string, eventId: string, data: { personalBest?: number; seasonBest?: number; worldRanking?: number }) => void
+  isPendingParticipation: boolean
+  t: (key: string) => string
+}) {
+  const [showEventPopup, setShowEventPopup] = useState(false)
+  const [showScorePopup, setShowScorePopup] = useState(false)
+  const [editingPerf, setEditingPerf] = useState(false)
+  const [perfForm, setPerfForm] = useState({
+    personalBest: app.waPerformance?.personalBest != null ? String(app.waPerformance.personalBest) : '',
+    seasonBest: app.waPerformance?.seasonBest != null ? String(app.waPerformance.seasonBest) : '',
+    worldRanking: app.waPerformance?.worldRanking != null ? String(app.waPerformance.worldRanking) : '',
+  })
+
+  const wp = app.waPerformance
+  const pb = wp?.personalBest ?? app.personalBest
+  const sb = wp?.seasonBest ?? app.seasonBest
+  const wr = wp?.worldRanking ?? app.worldRanking
+
+  const PARTICIPATION_COLORS: Record<string, string> = {
+    pending: 'bg-yellow-100 text-yellow-800',
+    selected: 'bg-green-100 text-green-800',
+    not_selected: 'bg-red-100 text-red-800',
+  }
+
+  return (
+    <div className="flex items-center gap-3 py-1.5 border-b border-gray-100 last:border-0">
+      {/* Event name with hover popup */}
+      <div className="relative shrink-0 w-28">
+        <button
+          onMouseEnter={() => setShowEventPopup(true)}
+          onMouseLeave={() => setShowEventPopup(false)}
+          className="font-medium text-sm text-gray-900 hover:text-blue-700 text-left truncate block w-full"
+        >
+          {app.event.catalog.name}
+        </button>
+        {showEventPopup && <ConfirmedAthletesPopup eventId={app.eventId} t={t} />}
+      </div>
+
+      {/* PB / SB (colored) / Ranking */}
+      {editingPerf ? (
+        <div className="flex gap-1 items-center flex-1">
+          <input type="number" step="0.01" placeholder="PB" className="w-20 px-1 py-0.5 border border-gray-300 rounded text-xs" value={perfForm.personalBest}
+            onChange={e => setPerfForm(p => ({ ...p, personalBest: e.target.value }))} />
+          <input type="number" step="0.01" placeholder="SB" className="w-20 px-1 py-0.5 border border-gray-300 rounded text-xs" value={perfForm.seasonBest}
+            onChange={e => setPerfForm(p => ({ ...p, seasonBest: e.target.value }))} />
+          <input type="number" placeholder="#" className="w-16 px-1 py-0.5 border border-gray-300 rounded text-xs" value={perfForm.worldRanking}
+            onChange={e => setPerfForm(p => ({ ...p, worldRanking: e.target.value }))} />
+          <button onClick={() => {
+            onWaPerfSave(athlete.id, app.eventId, {
+              ...(perfForm.personalBest ? { personalBest: parseFloat(perfForm.personalBest) } : {}),
+              ...(perfForm.seasonBest ? { seasonBest: parseFloat(perfForm.seasonBest) } : {}),
+              ...(perfForm.worldRanking ? { worldRanking: parseInt(perfForm.worldRanking) } : {}),
+            })
+            setEditingPerf(false)
+          }} className="text-[10px] text-green-600 hover:text-green-800">✓</button>
+          <button onClick={() => setEditingPerf(false)} className="text-[10px] text-gray-400 hover:text-gray-600">✕</button>
+        </div>
+      ) : (
+        <div className="flex items-center gap-3 text-xs text-gray-600 flex-1">
+          <span>PB: <span className="font-mono font-medium">{formatPerf(pb)}</span></span>
+          <span>SB: <span className={`font-mono font-medium ${sbColorClass(sb, app, athlete)}`}>{formatPerf(sb)}</span></span>
+          <span>#{wr ?? '—'}</span>
+
+          {/* Score with popup */}
+          {app.score != null && (
+            <div className="relative">
+              <button
+                onMouseEnter={() => setShowScorePopup(true)}
+                onMouseLeave={() => setShowScorePopup(false)}
+                className="font-mono font-bold text-sm text-gray-900 hover:text-blue-700"
+              >
+                {(app.score * 100).toFixed(0)}
+              </button>
+              {showScorePopup && edition && (
+                <ScoringPopup app={app} athlete={athlete} edition={edition} t={t} />
+              )}
+            </div>
+          )}
+
+          {/* Recommendation */}
+          {app.recommendation && (
+            <span className={`text-[10px] px-1.5 py-0.5 rounded ${
+              app.recommendation === 'Highly Recommended' ? 'bg-green-100 text-green-700' :
+              app.recommendation === 'Recommended' ? 'bg-blue-100 text-blue-700' :
+              app.recommendation === 'Under Review' ? 'bg-yellow-100 text-yellow-700' :
+              'bg-red-100 text-red-700'
+            }`}>
+              {app.recommendation}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Participation status */}
+      <div className="flex gap-1 shrink-0 items-center">
+        {isStaff && athlete.negotiationStatus !== 'confirmed' ? (
+          <>
+            {(['pending', 'selected', 'not_selected'] as const).map((status) => (
+              <button
+                key={status}
+                onClick={() => {
+                  if (app.participationStatus !== status) {
+                    onParticipationChange(app.id, status)
+                  }
+                }}
+                disabled={isPendingParticipation || app.participationStatus === status}
+                className={`text-[10px] px-2 py-0.5 rounded font-medium border ${
+                  app.participationStatus === status
+                    ? PARTICIPATION_COLORS[status] ?? 'bg-gray-100 text-gray-500'
+                    : 'border-gray-200 text-gray-400 hover:bg-gray-50'
+                }`}
+              >
+                {t(`participation.${status}`)}
+              </button>
+            ))}
+          </>
+        ) : (
+          <>
+            <span className={`text-[10px] px-2 py-0.5 rounded font-medium ${PARTICIPATION_COLORS[app.participationStatus] ?? 'bg-gray-100 text-gray-500'}`}>
+              {t(`participation.${app.participationStatus}`)}
+            </span>
+            {isStaff && athlete.negotiationStatus === 'confirmed' && (
+              <span className="text-[10px] text-gray-400" title={t('participation.lockedConfirmed')}>🔒</span>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Staff-only: edit perf + rescore */}
+      {isStaff && !editingPerf && (
+        <div className="flex gap-1 shrink-0">
+          <button onClick={() => setEditingPerf(true)} className="text-[10px] text-blue-600 hover:text-blue-800">
+            {t('selection.editPerformance')}
+          </button>
+          <button onClick={() => onRescore(app.id)} className="text-[10px] text-gray-400 hover:text-gray-600">
+            {t('selection.rescore')}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── CostPopup ───────────────────────────────────────────────────────────────
+
+export function CostPopup({ athlete, latestAgreement, costMode, t }: {
+  athlete: AthleteDetail
+  latestAgreement: Agreement | undefined
+  costMode: string
+  t: (key: string) => string
+}) {
+  return (
+    <div className="absolute z-20 right-0 top-6 bg-white border rounded-lg shadow-lg p-3 text-xs w-56">
+      {costMode === 'confirmed' && !latestAgreement ? (
+        <p className="text-green-700 italic">{t('selection.acceptedAtMeeting')}</p>
+      ) : costMode !== 'estimated' && latestAgreement ? (
+        <div className="space-y-1 text-gray-600">
+          {latestAgreement.appearanceFee > 0 && <div className="flex justify-between"><span>{t('contract.bonus')}</span><span>CHF {latestAgreement.appearanceFee}</span></div>}
+          {latestAgreement.transport > 0 && <div className="flex justify-between"><span>{t('contract.transport')}</span><span>CHF {latestAgreement.transport}</span></div>}
+          {latestAgreement.otherCompensation > 0 && <div className="flex justify-between"><span>{t('contract.otherCompensation')}</span><span>CHF {latestAgreement.otherCompensation}</span></div>}
+          <div className="border-t pt-1 mt-1 flex justify-between font-semibold text-gray-900">
+            <span>{t('contract.totalCost')}</span>
+            <span>CHF {(latestAgreement.totalCost ?? 0).toLocaleString()}</span>
+          </div>
+          <div className="text-[10px] text-gray-400">v{latestAgreement.version} — {new Date(latestAgreement.sentAt).toLocaleDateString()}</div>
+        </div>
+      ) : (
+        <div className="space-y-1 text-gray-600">
+          <div className="flex justify-between"><span>{t('collaborator.estTravel')}</span><span>CHF {athlete.estTravel}</span></div>
+          <div className="flex justify-between"><span>{t('collaborator.estAccommodation')}</span><span>CHF {athlete.estAccommodation}</span></div>
+          <div className="flex justify-between"><span>{t('collaborator.estAppearance')}</span><span>CHF {athlete.estAppearance}</span></div>
+          <div className="border-t pt-1 mt-1 flex justify-between font-semibold text-gray-900">
+            <span>{t('contract.totalCost')}</span>
+            <span>CHF {(athlete.estTotal ?? 0).toLocaleString()}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/web/pages/collaborator/athlete/NegotiationTab.tsx
+++ b/src/web/pages/collaborator/athlete/NegotiationTab.tsx
@@ -1,0 +1,148 @@
+import { useTranslation } from 'react-i18next'
+import { inputCls } from '@web/lib/ui-constants'
+import type { AthleteDetail, Interaction } from '@shared/types'
+import { AgreementCard, CounterOfferCard, InteractionCard } from './components'
+
+type TimelineItem =
+  | { kind: 'agreement'; id: string; date: string; data: AthleteDetail['agreements'][number] }
+  | { kind: 'counter_offer'; id: string; date: string; data: Interaction }
+
+export function NegotiationTab({ athlete, isStaff, isAthleteOrManager, canSendAgreement, onShowAgreementForm, noteType, onNoteTypeChange, noteContent, onNoteContentChange, onAddNote, isNotePending, onViewEmail }: {
+  athlete: AthleteDetail
+  isStaff: boolean
+  isAthleteOrManager: boolean
+  canSendAgreement: boolean
+  onShowAgreementForm: () => void
+  noteType: 'note' | 'call' | 'email'
+  onNoteTypeChange: (type: 'note' | 'call' | 'email') => void
+  noteContent: string
+  onNoteContentChange: (content: string) => void
+  onAddNote: () => void
+  isNotePending: boolean
+  onViewEmail: (emailLogId: string) => void
+}) {
+  const { t, i18n } = useTranslation()
+
+  const currentStatus = athlete.negotiationStatus
+  const latestAgreement = athlete.agreements.length
+    ? athlete.agreements[athlete.agreements.length - 1]
+    : undefined
+
+  const selectedEventNames = athlete.applications
+    .filter(a => a.participationStatus === 'selected')
+    .map(a => `${a.event.catalog.name} ${a.event.catalog.gender === 'M' ? (i18n.language === 'fr' ? 'Hommes' : 'Men') : (i18n.language === 'fr' ? 'Femmes' : 'Women')}`)
+  const meetingName = athlete.edition?.name ?? 'Atletica Geneve'
+
+  const agreementItems: TimelineItem[] = athlete.agreements.map(a => ({
+    kind: 'agreement' as const,
+    id: a.id,
+    date: a.sentAt,
+    data: a,
+  }))
+
+  const counterOfferItems: TimelineItem[] = athlete.interactions
+    .filter(i => i.type === 'counter_offer')
+    .map(i => ({
+      kind: 'counter_offer' as const,
+      id: i.id,
+      date: i.createdAt,
+      data: i,
+    }))
+
+  const toMs = (d: string) =>
+    new Date(d.includes('T') ? d : d.replace(' ', 'T') + 'Z').getTime()
+  const timelineItems = [...agreementItems, ...counterOfferItems]
+    .sort((a, b) => toMs(b.date) - toMs(a.date))
+
+  return (
+    <div className="grid grid-cols-2 gap-6">
+      {/* Left: Agreements */}
+      <div className="space-y-4">
+        <div className="bg-white rounded-lg border p-4">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="font-semibold text-sm">{t('contract.title')}</h3>
+            {isStaff && (currentStatus === 'to_review' || currentStatus === 'counter_offer_sent') && (
+              <button
+                onClick={onShowAgreementForm}
+                disabled={!canSendAgreement}
+                title={!canSendAgreement ? t('selection.decideAllFirst') : undefined}
+                className={`text-xs ${canSendAgreement ? 'text-blue-600 hover:text-blue-800' : 'text-gray-300 cursor-not-allowed'}`}
+              >
+                {latestAgreement ? t('contract.newVersion') : t('action.sendAgreement')}
+              </button>
+            )}
+          </div>
+
+          {currentStatus === 'confirmed' && timelineItems.length === 0 ? (
+            <p className="text-sm text-green-700 italic">{t('selection.acceptedAtMeeting')}</p>
+          ) : timelineItems.length === 0 ? (
+            <p className="text-xs text-gray-400">{t('contract.noOfferYet')}</p>
+          ) : (
+            <div className="space-y-3">
+              {timelineItems.map(item =>
+                item.kind === 'agreement'
+                  ? (
+                    <AgreementCard
+                      key={item.id}
+                      agreement={item.data}
+                      selectedEventNames={selectedEventNames}
+                      meetingName={meetingName}
+                      lang={i18n.language}
+                      isStaff={!!isStaff}
+                      t={t}
+                    />
+                  )
+                  : <CounterOfferCard key={item.id} interaction={item.data} />
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Right: Timeline */}
+      <div className="space-y-4">
+        <div className="bg-white rounded-lg border p-4">
+          <h3 className="font-semibold text-sm mb-3">{t('collaborator.addNote')}</h3>
+          {isStaff && (
+            <select
+              className={`${inputCls} mb-2`}
+              value={noteType}
+              onChange={e => onNoteTypeChange(e.target.value as 'note' | 'call' | 'email')}
+            >
+              <option value="note">{t('collaborator.note')}</option>
+              <option value="call">{t('collaborator.phoneCall')}</option>
+              <option value="email">{t('athlete.email')}</option>
+            </select>
+          )}
+          <textarea
+            className={inputCls}
+            rows={3}
+            placeholder={t('collaborator.enterNote')}
+            value={noteContent}
+            onChange={e => onNoteContentChange(e.target.value)}
+          />
+          <button
+            onClick={onAddNote}
+            disabled={isNotePending || !noteContent.trim()}
+            className="mt-2 text-xs bg-gray-900 text-white px-3 py-1.5 rounded hover:bg-gray-800 disabled:opacity-50"
+          >
+            {t('common.add')}
+          </button>
+        </div>
+
+        <div className="bg-white rounded-lg border p-4">
+          <h3 className="font-semibold text-sm mb-3">{t('collaborator.timeline')}</h3>
+          {athlete.interactions.length === 0 ? (
+            <p className="text-xs text-gray-400">{t('collaborator.noInteractions')}</p>
+          ) : (
+            <div className="space-y-3 max-h-96 overflow-y-auto">
+              {athlete.interactions.map(interaction => (
+                <InteractionCard key={interaction.id} interaction={interaction} onViewEmail={onViewEmail} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/web/pages/collaborator/athlete/PersonalTab.tsx
+++ b/src/web/pages/collaborator/athlete/PersonalTab.tsx
@@ -1,0 +1,184 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { inputCls } from '@web/lib/ui-constants'
+import type { AthleteDetail } from '@shared/types'
+import type { FieldDef, StaffUser } from './types'
+import { CollapsibleSection, FieldReadOnly, AthleteFieldEditor, SelectorAssign } from './components'
+
+export function PersonalTab({ athlete, isStaff, isAthleteOrManager, staffUsers, mutations }: {
+  athlete: AthleteDetail
+  isStaff: boolean
+  isAthleteOrManager: boolean
+  staffUsers: StaffUser[]
+  mutations: {
+    athleteUpdate: { mutate: (data: Record<string, unknown>) => void; isPending: boolean; error: Error | null }
+    internalNotes: { mutate: (notes: string) => void; isPending: boolean }
+  }
+}) {
+  const { t } = useTranslation()
+  const [openSection, setOpenSection] = useState<string | null>('identity')
+  const [editingSection, setEditingSection] = useState<string | null>(null)
+  const [internalNotes, setInternalNotes] = useState(athlete.internalNotes ?? '')
+
+  const toggleSection = (name: string) => setOpenSection(openSection === name ? null : name)
+  const toggleEdit = (section: string) => setEditingSection(editingSection === section ? null : section)
+
+  const identityFields: FieldDef[] = [
+    { key: 'firstName', label: t('athlete.firstName'), type: 'text' },
+    { key: 'lastName', label: t('athlete.lastName'), type: 'text' },
+    { key: 'dateOfBirth', label: t('athlete.dateOfBirth'), type: 'date' },
+    { key: 'nationality', label: t('athlete.nationality'), type: 'text' },
+    { key: 'gender', label: t('athlete.gender'), type: 'select', options: [
+      { value: 'M', label: t('athlete.male') }, { value: 'F', label: t('athlete.female') }
+    ]},
+    { key: 'federation', label: t('athlete.federation'), type: 'text' },
+    { key: 'club', label: t('athlete.club'), type: 'text' },
+    { key: 'athleteEmail', label: t('athlete.email'), type: 'text' },
+    { key: 'athletePhone', label: t('athlete.phone'), type: 'text' },
+    { key: 'waProfileUrl', label: t('athlete.waProfile'), type: 'text' },
+    { key: 'swiLicence', label: t('athlete.swissLicence'), type: 'text' },
+    { key: 'honours', label: t('athlete.honours'), type: 'text' },
+    { key: 'distanceFromGva', label: t('athlete.distanceFromGva'), type: 'number' },
+    { key: 'isEap', label: t('athlete.eapMember'), type: 'checkbox' },
+    { key: 'isSwiss', label: t('athlete.swiss'), type: 'checkbox' },
+    { key: 'eapCity', label: t('athlete.eapCity'), type: 'text' },
+  ]
+
+  const athleteIdentityFields: FieldDef[] = identityFields.filter(f =>
+    ['athleteEmail', 'athletePhone'].includes(f.key)
+  )
+
+  const complianceFields: FieldDef[] = [
+    { key: 'iRunClean', label: t('compliance.iRunClean'), type: 'select', options: [
+      { value: 'yes', label: t('common.yes') }, { value: 'no', label: t('common.no') },
+      { value: 'in_progress', label: t('common.inProgress') }, { value: 'unknown', label: t('common.unknown') },
+    ]},
+    { key: 'dopingFree', label: t('compliance.dopingFree'), type: 'select', options: [
+      { value: 'yes', label: t('common.yes') }, { value: 'no', label: t('common.no') }, { value: 'unknown', label: t('common.unknown') },
+    ]},
+  ]
+
+  const logisticsFields: FieldDef[] = [
+    { key: 'arrivalDate', label: `${t('logistics.arrival')} ${t('logistics.date')}`, type: 'date' },
+    { key: 'arrivalFlight', label: `${t('logistics.arrival')} ${t('logistics.flightNumber')}`, type: 'text' },
+    { key: 'arrivalFrom', label: `${t('logistics.arrival')} ${t('logistics.from')}`, type: 'text' },
+    { key: 'arrivalTime', label: `${t('logistics.arrival')} ${t('logistics.time')}`, type: 'text' },
+    { key: 'departureDate', label: `${t('logistics.departure')} ${t('logistics.date')}`, type: 'date' },
+    { key: 'departureFlight', label: `${t('logistics.departure')} ${t('logistics.flightNumber')}`, type: 'text' },
+    { key: 'departureTo', label: `${t('logistics.departure')} ${t('logistics.to')}`, type: 'text' },
+    { key: 'departureTime', label: `${t('logistics.departure')} ${t('logistics.time')}`, type: 'text' },
+    { key: 'accommodationReqs', label: t('logistics.specialRequests'), type: 'textarea' },
+  ]
+
+  const costFields: FieldDef[] = [
+    { key: 'estAppearance', label: t('collaborator.estAppearance'), type: 'number' },
+    { key: 'estTravel', label: t('collaborator.estTravel'), type: 'number' },
+    { key: 'estAccommodation', label: t('collaborator.estAccommodation'), type: 'number' },
+    { key: 'estTotal', label: t('selection.estimatedCost'), type: 'number' },
+  ]
+
+  const paymentFields: FieldDef[] = [
+    { key: 'bankIban', label: t('collaborator.iban'), type: 'text' },
+    { key: 'paymentStatus', label: t('collaborator.paymentStatus'), type: 'select', options: [
+      { value: 'pending', label: t('common.pending') }, { value: 'done', label: t('common.done') },
+    ]},
+    { key: 'paymentAmount', label: t('collaborator.paymentAmount'), type: 'number' },
+    { key: 'paymentDate', label: t('collaborator.paymentDate'), type: 'date' },
+    { key: 'paymentMethod', label: t('collaborator.paymentMethod'), type: 'select', options: [
+      { value: '', label: '—' }, { value: 'cash', label: t('collaborator.cash') },
+      { value: 'bank', label: t('collaborator.bank') }, { value: 'western_union', label: t('collaborator.westernUnion') },
+      { value: 'paypal', label: t('collaborator.paypal') }, { value: 'other', label: t('collaborator.other') },
+    ]},
+  ]
+
+  const renderSection = (name: string, title: string, fields: FieldDef[], canEdit: boolean) => (
+    <CollapsibleSection
+      title={title}
+      isOpen={openSection === name}
+      onToggle={() => toggleSection(name)}
+      canEdit={canEdit}
+      isEditing={editingSection === name}
+      onToggleEdit={() => toggleEdit(name)}
+    >
+      {editingSection === name && canEdit ? (
+        <AthleteFieldEditor
+          athlete={athlete}
+          fields={fields}
+          onSave={(data) => { mutations.athleteUpdate.mutate(data); setEditingSection(null) }}
+          isPending={mutations.athleteUpdate.isPending}
+          error={mutations.athleteUpdate.error}
+          t={t}
+        />
+      ) : (
+        <FieldReadOnly athlete={athlete} fields={fields} t={t} />
+      )}
+    </CollapsibleSection>
+  )
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <div className="space-y-4">
+        {isStaff
+          ? renderSection('identity', t('collaborator.identity'), identityFields, true)
+          : (
+            <>
+              <CollapsibleSection title={t('collaborator.identity')} isOpen={openSection === 'identity'} onToggle={() => toggleSection('identity')}>
+                <FieldReadOnly athlete={athlete} fields={identityFields.filter(f => !['athleteEmail', 'athletePhone'].includes(f.key))} t={t} />
+              </CollapsibleSection>
+              {renderSection('contact', t('athlete.contact'), athleteIdentityFields, true)}
+            </>
+          )
+        }
+        {renderSection('compliance', t('compliance.title'), complianceFields, true)}
+        {renderSection('logistics', t('logistics.title'), logisticsFields, true)}
+      </div>
+
+      <div className="space-y-4">
+        {isStaff && (
+          <CollapsibleSection title={t('selection.assignedSelector')} isOpen={openSection === 'selector'} onToggle={() => toggleSection('selector')}>
+            <SelectorAssign
+              currentValue={athlete.assignedSelector}
+              staffUsers={staffUsers}
+              onSave={(val) => mutations.athleteUpdate.mutate({ assignedSelector: val || null })}
+              isPending={mutations.athleteUpdate.isPending}
+              t={t}
+            />
+          </CollapsibleSection>
+        )}
+        {isStaff && renderSection('costs', t('selection.estimatedCost'), costFields, false)}
+        {isStaff && renderSection('payment', t('collaborator.payment'), paymentFields, true)}
+
+        <CollapsibleSection title={t('common.notes')} isOpen={openSection === 'notes'} onToggle={() => toggleSection('notes')}>
+          <div className="space-y-3">
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">{t('collaborator.participantNotes')}</label>
+              <p className="text-xs text-gray-600 bg-gray-50 p-2 rounded min-h-[2rem]">{athlete.participantNotes || '—'}</p>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">{t('collaborator.additionalNotes')}</label>
+              <p className="text-xs text-gray-600 bg-gray-50 p-2 rounded min-h-[2rem]">{athlete.additionalNotes || '—'}</p>
+            </div>
+            {isStaff && (
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">{t('collaborator.internalNotes')}</label>
+                <textarea
+                  className={inputCls}
+                  rows={3}
+                  value={internalNotes}
+                  onChange={(e) => setInternalNotes(e.target.value)}
+                />
+                <button
+                  onClick={() => mutations.internalNotes.mutate(internalNotes)}
+                  disabled={mutations.internalNotes.isPending}
+                  className="mt-2 text-xs bg-gray-900 text-white px-3 py-1 rounded hover:bg-gray-800 disabled:opacity-50"
+                >
+                  {t('common.save')}
+                </button>
+              </div>
+            )}
+          </div>
+        </CollapsibleSection>
+      </div>
+    </div>
+  )
+}

--- a/src/web/pages/collaborator/athlete/components.tsx
+++ b/src/web/pages/collaborator/athlete/components.tsx
@@ -1,0 +1,252 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { formatAgreementTerms } from '@shared/agreementFormatter'
+import { inputCls } from '@web/lib/ui-constants'
+import type { Athlete, Agreement, Interaction } from '@shared/types'
+import type { FieldDef } from './types'
+
+// ── CollapsibleSection ──────────────────────────────────────────────────────
+
+export function CollapsibleSection({ title, isOpen, onToggle, canEdit, isEditing, onToggleEdit, children }: {
+  title: string; isOpen: boolean; onToggle: () => void
+  canEdit?: boolean; isEditing?: boolean; onToggleEdit?: () => void
+  children: React.ReactNode
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="bg-white rounded-lg border">
+      <button onClick={onToggle} className="w-full flex items-center justify-between p-3 text-sm font-semibold hover:bg-gray-50">
+        <span>{title}</span>
+        <span className="flex items-center gap-2">
+          {canEdit && isOpen && (
+            <span
+              onClick={e => { e.stopPropagation(); onToggleEdit?.() }}
+              className={`text-xs cursor-pointer px-1.5 py-0.5 rounded ${isEditing ? 'text-blue-600 bg-blue-50' : 'text-gray-400 hover:text-gray-600'}`}
+              title={isEditing ? t('common.cancelEdit') : t('common.edit')}
+            >
+              ✎
+            </span>
+          )}
+          <span className="text-gray-400 text-xs">{isOpen ? '▾' : '▸'}</span>
+        </span>
+      </button>
+      {isOpen && <div className="px-4 pb-4">{children}</div>}
+    </div>
+  )
+}
+
+// ── FieldReadOnly ───────────────────────────────────────────────────────────
+
+export function FieldReadOnly({ athlete, fields, t }: {
+  athlete: Athlete; fields: FieldDef[]; t: (key: string) => string
+}) {
+  return (
+    <div className="space-y-1.5">
+      {fields.map(f => {
+        const raw = (athlete as unknown as Record<string, unknown>)[f.key]
+        let display: string
+        if (f.type === 'checkbox') {
+          display = raw ? t('common.yes') : t('common.no')
+        } else if (f.type === 'select') {
+          display = f.options?.find(o => o.value === raw)?.label ?? String(raw ?? '—')
+        } else {
+          display = raw != null && raw !== '' && raw !== 0 ? String(raw) : '—'
+        }
+        return (
+          <div key={f.key} className="flex justify-between text-xs">
+            <span className="text-gray-500">{f.label}</span>
+            <span className="text-gray-900 font-medium text-right max-w-[60%] truncate">{display}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// ── AthleteFieldEditor ──────────────────────────────────────────────────────
+
+export function AthleteFieldEditor({ athlete, fields, onSave, isPending, error, t }: {
+  athlete: Athlete
+  fields: FieldDef[]
+  onSave: (data: Record<string, unknown>) => void
+  isPending: boolean
+  error: Error | null
+  t: (key: string) => string
+}) {
+  const [form, setForm] = useState<Record<string, unknown>>(() => {
+    const init: Record<string, unknown> = {}
+    for (const f of fields) {
+      init[f.key] = (athlete as unknown as Record<string, unknown>)[f.key] ?? (f.type === 'checkbox' ? false : f.type === 'number' ? 0 : '')
+    }
+    return init
+  })
+
+  return (
+    <div className="space-y-2">
+      {fields.map(f => (
+        <div key={f.key}>
+          {f.type === 'checkbox' ? (
+            <label className="flex items-center gap-2 text-xs cursor-pointer">
+              <input type="checkbox" checked={form[f.key] as boolean}
+                onChange={e => setForm(p => ({ ...p, [f.key]: e.target.checked }))} />
+              {f.label}
+            </label>
+          ) : f.type === 'select' ? (
+            <>
+              <label className="block text-xs font-medium text-gray-500 mb-1">{f.label}</label>
+              <select className={inputCls} value={form[f.key] as string}
+                onChange={e => setForm(p => ({ ...p, [f.key]: e.target.value }))}>
+                {f.options?.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </>
+          ) : f.type === 'textarea' ? (
+            <>
+              <label className="block text-xs font-medium text-gray-500 mb-1">{f.label}</label>
+              <textarea className={inputCls} rows={2} value={form[f.key] as string}
+                onChange={e => setForm(p => ({ ...p, [f.key]: e.target.value }))} />
+            </>
+          ) : (
+            <>
+              <label className="block text-xs font-medium text-gray-500 mb-1">{f.label}</label>
+              <input type={f.type} className={inputCls} value={form[f.key] as string | number}
+                onChange={e => setForm(p => ({ ...p, [f.key]: f.type === 'number' ? (parseInt(e.target.value) || 0) : e.target.value }))} />
+            </>
+          )}
+        </div>
+      ))}
+      <button
+        onClick={() => onSave(form)}
+        disabled={isPending}
+        className="mt-2 text-xs bg-gray-900 text-white px-3 py-1 rounded hover:bg-gray-800 disabled:opacity-50"
+      >
+        {t('common.save')}
+      </button>
+      {error && <p className="text-xs text-red-600">{error.message || t('common.error')}</p>}
+    </div>
+  )
+}
+
+// ── SelectorAssign ──────────────────────────────────────────────────────────
+
+export function SelectorAssign({ currentValue, staffUsers, onSave, isPending, t }: {
+  currentValue: string | null
+  staffUsers: { id: string; firstName: string; lastName: string }[]
+  onSave: (val: string) => void
+  isPending: boolean
+  t: (key: string) => string
+}) {
+  const [value, setValue] = useState(currentValue ?? '')
+  return (
+    <div className="space-y-2">
+      <select
+        className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-900"
+        value={value}
+        onChange={e => setValue(e.target.value)}
+      >
+        <option value="">— {t('common.unassigned')} —</option>
+        {staffUsers.map(u => (
+          <option key={u.id} value={u.id}>{u.firstName} {u.lastName}</option>
+        ))}
+      </select>
+      <button
+        onClick={() => onSave(value)}
+        disabled={isPending}
+        className="text-xs bg-gray-900 text-white px-3 py-1 rounded hover:bg-gray-800 disabled:opacity-50"
+      >
+        {t('common.save')}
+      </button>
+    </div>
+  )
+}
+
+// ── AgreementCard ───────────────────────────────────────────────────────────
+
+export function AgreementCard({
+  agreement: c,
+  selectedEventNames,
+  meetingName,
+  lang,
+  isStaff,
+  t,
+}: {
+  agreement: Agreement
+  selectedEventNames: string[]
+  meetingName: string
+  lang: string
+  isStaff: boolean
+  t: (key: string) => string
+}) {
+  const formattedLang = (lang === 'fr' ? 'fr' : 'en') as 'en' | 'fr'
+  const formattedText = formatAgreementTerms(c, selectedEventNames, meetingName, formattedLang)
+
+  return (
+    <div className="p-3 rounded border border-blue-200 bg-blue-50 text-xs">
+      <pre className="whitespace-pre-wrap font-sans text-gray-700 leading-relaxed">{formattedText}</pre>
+      {isStaff && c.totalCost > 0 && (
+        <div className="mt-2 pt-2 border-t border-blue-200 font-semibold text-gray-900">
+          {t('contract.totalCost')}: CHF {c.totalCost.toLocaleString()}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── CounterOfferCard ────────────────────────────────────────────────────────
+
+export function CounterOfferCard({ interaction }: { interaction: Interaction }) {
+  return (
+    <div className="p-3 rounded border border-rose-200 bg-rose-50 text-xs">
+      <div className="flex justify-between mb-1">
+        <span className="font-semibold text-rose-700">{interaction.authorName}</span>
+        <span className="text-gray-500">{new Date(interaction.createdAt).toLocaleDateString()}</span>
+      </div>
+      <p className="text-gray-700 whitespace-pre-wrap">{interaction.content}</p>
+    </div>
+  )
+}
+
+// ── InteractionCard ─────────────────────────────────────────────────────────
+
+export function InteractionCard({ interaction, onViewEmail }: { interaction: Interaction; onViewEmail?: (emailLogId: string) => void }) {
+  const { t } = useTranslation()
+  const typeIcons: Record<string, string> = {
+    status_change: '●',
+    agreement: '■',
+    counter_offer: '◆',
+    note: '✎',
+    call: '☎',
+    email: '✉',
+  }
+
+  const typeColors: Record<string, string> = {
+    status_change: 'text-blue-500',
+    agreement: 'text-green-500',
+    counter_offer: 'text-purple-500',
+    note: 'text-gray-500',
+    call: 'text-orange-500',
+    email: 'text-indigo-500',
+  }
+
+  const hasEmail = !!interaction.emailLogId
+  const clickable = hasEmail && onViewEmail
+
+  return (
+    <div
+      className={`flex gap-2 ${clickable ? 'cursor-pointer hover:bg-gray-50 rounded p-1 -m-1' : ''}`}
+      onClick={clickable ? () => onViewEmail(interaction.emailLogId!) : undefined}
+    >
+      <span className={`${typeColors[interaction.type] ?? 'text-gray-400'} mt-0.5 shrink-0`}>
+        {typeIcons[interaction.type] ?? '●'}
+      </span>
+      <div className="flex-1 min-w-0">
+        <p className="text-xs text-gray-900">
+          {interaction.content}
+          {hasEmail && <span className="ml-1 text-indigo-500" title={t('common.viewEmail')}>✉</span>}
+        </p>
+        <p className="text-[10px] text-gray-400 mt-0.5">
+          {interaction.authorName} — {new Date(interaction.createdAt).toLocaleString()}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/web/pages/collaborator/athlete/modals.tsx
+++ b/src/web/pages/collaborator/athlete/modals.tsx
@@ -1,0 +1,390 @@
+import { useTranslation } from 'react-i18next'
+import { NIGHT_LABELS, DINNER_LABELS } from '@shared/constants'
+import { inputCls, labelCls } from '@web/lib/ui-constants'
+import type { NegotiationStatus, AthleteDetail, Agreement } from '@shared/types'
+import type { AgreementFormDraft, HotelWithRooms } from './types'
+
+// ── Confirm transition dialog ───────────────────────────────────────────────
+
+export function ConfirmTransitionDialog({ fromStatus, toStatus, athlete, onConfirm, onCancel, isPending }: {
+  fromStatus: NegotiationStatus
+  toStatus: NegotiationStatus
+  athlete: AthleteDetail
+  onConfirm: () => void
+  onCancel: () => void
+  isPending: boolean
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={onCancel}>
+      <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 p-6" onClick={e => e.stopPropagation()}>
+        <p className="text-sm text-gray-900 mb-5 leading-relaxed">
+          {t(`confirm.transition.${fromStatus}__${toStatus}`, {
+            athlete: `${athlete.firstName} ${athlete.lastName}`,
+            meeting: athlete.edition?.name ?? '',
+          })}
+        </p>
+        <div className="flex gap-2 justify-end">
+          <button
+            onClick={onCancel}
+            className="text-xs px-3 py-1.5 rounded border border-gray-300 hover:bg-gray-50"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isPending}
+            className={`text-xs px-3 py-1.5 rounded font-medium text-white disabled:opacity-50 ${
+              toStatus === 'rejected'
+                ? 'bg-red-600 hover:bg-red-700'
+                : toStatus === 'to_review'
+                ? 'bg-orange-600 hover:bg-orange-700'
+                : toStatus === 'confirmed'
+                ? 'bg-green-600 hover:bg-green-700'
+                : toStatus === 'withdrawn'
+                ? 'bg-gray-600 hover:bg-gray-700'
+                : 'bg-blue-600 hover:bg-blue-700'
+            }`}
+          >
+            {t('common.confirm')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Email preview modal ─────────────────────────────────────────────────────
+
+export function EmailPreviewModal({ emailPreview, onClose }: {
+  emailPreview: { subject: string; body: string }
+  onClose: () => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={onClose}>
+      <div className="bg-white rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[80vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between p-4 border-b">
+          <h3 className="font-semibold text-sm">{t('emailPreview.title')}</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">✕</button>
+        </div>
+        <div className="p-4 text-sm space-y-3">
+          <p className="text-xs text-gray-500">{t('emailPreview.description')}</p>
+          <div className="text-xs text-gray-700">
+            <span className="font-medium">{t('emailPreview.subject')}:</span> {emailPreview.subject}
+          </div>
+          <pre className="text-xs text-gray-700 whitespace-pre-wrap bg-gray-50 p-3 rounded border">{emailPreview.body}</pre>
+          <div className="flex justify-end">
+            <button
+              onClick={onClose}
+              className="text-xs px-4 py-1.5 rounded font-medium bg-gray-900 text-white hover:bg-gray-800"
+            >
+              {t('common.close')}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Email popup (viewing sent email) ────────────────────────────────────────
+
+export function EmailPopupModal({ email, onClose }: {
+  email: { subject: string; body: string; htmlBody?: string; to: string; sentAt: string } | undefined
+  onClose: () => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={onClose}>
+      <div className="bg-white rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[80vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between p-4 border-b">
+          <h3 className="font-semibold text-sm">{t('collaborator.emailDetail')}</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">✕</button>
+        </div>
+        {email ? (
+          <div className="p-4 text-sm space-y-2">
+            <div className="text-xs text-gray-500">
+              <span className="font-medium">{t('admin.emailTo')}:</span> {email.to}
+            </div>
+            <div className="text-xs text-gray-500">
+              <span className="font-medium">{t('admin.subject')}:</span> {email.subject}
+            </div>
+            <div className="text-xs text-gray-400">
+              {new Date(email.sentAt).toLocaleString()}
+            </div>
+            <div className="border-t pt-3 mt-2">
+              {email.htmlBody ? (
+                <div className="text-sm prose prose-sm max-w-none" dangerouslySetInnerHTML={{ __html: email.htmlBody }} />
+              ) : (
+                <pre className="text-xs text-gray-700 whitespace-pre-wrap">{email.body}</pre>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="p-4 text-sm text-gray-400">{t('common.loading')}</div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Counter-offer modal ─────────────────────────────────────────────────────
+
+export function CounterOfferModal({ text, onTextChange, onSubmit, onCancel, isPending, error }: {
+  text: string
+  onTextChange: (text: string) => void
+  onSubmit: () => void
+  onCancel: () => void
+  isPending: boolean
+  error: Error | null
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="mt-3 p-4 rounded border border-purple-300 bg-purple-50">
+      <h3 className="text-sm font-semibold text-gray-900 mb-2">{t('action.counterOffer')}</h3>
+      <textarea
+        className="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-purple-500"
+        rows={4}
+        placeholder={t('action.counterOfferPlaceholder')}
+        value={text}
+        onChange={e => onTextChange(e.target.value)}
+      />
+      <div className="flex gap-2 mt-2">
+        <button
+          onClick={onSubmit}
+          disabled={isPending || !text.trim()}
+          className="text-xs px-3 py-1.5 rounded font-medium bg-purple-600 text-white hover:bg-purple-700 disabled:opacity-50"
+        >
+          {isPending ? t('common.loading') : t('common.submit')}
+        </button>
+        <button
+          onClick={onCancel}
+          className="text-xs px-3 py-1.5 rounded border border-gray-300 hover:bg-gray-50"
+        >
+          {t('common.cancel')}
+        </button>
+      </div>
+      {error && (
+        <p className="text-xs text-red-600 mt-1">{error.message || t('common.error')}</p>
+      )}
+    </div>
+  )
+}
+
+// ── Free message modal ──────────────────────────────────────────────────────
+
+export function MessageModal({ text, onTextChange, onSubmit, onCancel, isPending, error }: {
+  text: string
+  onTextChange: (text: string) => void
+  onSubmit: () => void
+  onCancel: () => void
+  isPending: boolean
+  error: Error | null
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="mt-3 p-4 rounded border border-gray-300 bg-gray-50">
+      <h3 className="text-sm font-semibold text-gray-900 mb-2">{t('action.sendMessage')}</h3>
+      <textarea
+        className="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-500"
+        rows={3}
+        placeholder={t('action.messagePlaceholder')}
+        value={text}
+        onChange={e => onTextChange(e.target.value)}
+      />
+      <div className="flex gap-2 mt-2">
+        <button
+          onClick={onSubmit}
+          disabled={isPending || !text.trim()}
+          className="text-xs px-3 py-1.5 rounded font-medium bg-gray-900 text-white hover:bg-gray-800 disabled:opacity-50"
+        >
+          {isPending ? t('common.loading') : t('common.submit')}
+        </button>
+        <button
+          onClick={onCancel}
+          className="text-xs px-3 py-1.5 rounded border border-gray-300 hover:bg-gray-50"
+        >
+          {t('common.cancel')}
+        </button>
+      </div>
+      {error && (
+        <p className="text-xs text-red-600 mt-1">{error.message || t('common.error')}</p>
+      )}
+    </div>
+  )
+}
+
+// ── Agreement form modal ────────────────────────────────────────────────────
+
+export function AgreementFormModal({ form, onChange, allRooms, athlete, onSubmit, onClose, isPending, error }: {
+  form: AgreementFormDraft
+  onChange: (updater: (prev: AgreementFormDraft) => AgreementFormDraft) => void
+  allRooms: { id: string; hotelName: string; roomType: string; costPerNight: number; dinnerCost: number }[]
+  athlete: AthleteDetail
+  onSubmit: () => void
+  onClose: () => void
+  isPending: boolean
+  error: Error | null
+}) {
+  const { t } = useTranslation()
+
+  const room = allRooms.find(r => r.id === form.hotelRoomId)
+  const nights = NIGHT_LABELS.filter(n => form[`hotelNight${n.charAt(0).toUpperCase() + n.slice(1)}` as keyof AgreementFormDraft]).length
+  const dinners = DINNER_LABELS.filter(d => form[`dinner${d.charAt(0).toUpperCase() + d.slice(1)}` as keyof AgreementFormDraft]).length
+  let total = (form.appearanceFee || 0) + (form.otherCompensation || 0) + (form.transport || 0)
+  total += nights * (room?.costPerNight ?? 0)
+  total += dinners * (room?.dinnerCost ?? 0)
+  if (form.stadiumMeals) total += athlete.edition?.stadiumMealCost ?? 0
+  if (form.transportAirportHotel) total += athlete.edition?.transportAirportHotelCost ?? 0
+  if (form.transportHotelStadium) total += athlete.edition?.transportHotelStadiumCost ?? 0
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={onClose}>
+      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between p-4 border-b">
+          <h3 className="font-semibold text-sm">
+            {t('contract.sendOffer')} — v{(athlete.agreements.length || 0) + 1}
+          </h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">✕</button>
+        </div>
+        <div className="p-4 space-y-3">
+          <div>
+            <label className={labelCls}>{t('contract.bonus')} (CHF)</label>
+            <input
+              type="number"
+              className={`${inputCls} text-right`}
+              value={form.appearanceFee}
+              placeholder="0"
+              onChange={e => onChange(p => ({ ...p, appearanceFee: e.target.value === '' ? '' : (parseInt(e.target.value) || 0) }))}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelCls}>{t('contract.otherCompensation')} (CHF)</label>
+              <input
+                type="number"
+                className={`${inputCls} text-right`}
+                value={form.otherCompensation}
+                placeholder="0"
+                onChange={e => onChange(p => ({ ...p, otherCompensation: e.target.value === '' ? '' : (parseInt(e.target.value) || 0) }))}
+              />
+            </div>
+            <div>
+              <label className={labelCls}>{t('contract.description')}</label>
+              <input
+                className={inputCls}
+                value={form.otherCompensationDesc}
+                onChange={e => onChange(p => ({ ...p, otherCompensationDesc: e.target.value }))}
+                placeholder={t('contract.otherCompensationDesc')}
+              />
+            </div>
+          </div>
+          <div>
+            <label className={labelCls}>{t('contract.transport')} (CHF)</label>
+            <input
+              type="number"
+              className={`${inputCls} text-right`}
+              value={form.transport}
+              placeholder="0"
+              onChange={e => onChange(p => ({ ...p, transport: e.target.value === '' ? '' : (parseInt(e.target.value) || 0) }))}
+            />
+          </div>
+          <div className="flex items-center gap-4">
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input type="checkbox" checked={form.transportAirportHotel}
+                onChange={e => onChange(p => ({ ...p, transportAirportHotel: e.target.checked }))} />
+              {t('contract.transportAirportHotel')}
+            </label>
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input type="checkbox" checked={form.transportHotelStadium}
+                onChange={e => onChange(p => ({ ...p, transportHotelStadium: e.target.checked }))} />
+              {t('contract.transportHotelStadium')}
+            </label>
+          </div>
+          <div>
+            <label className={labelCls}>{t('logistics.hotel')}</label>
+            <select className={inputCls} value={form.hotelRoomId}
+              onChange={e => onChange(p => ({ ...p, hotelRoomId: e.target.value }))}>
+              <option value="">— {t('contract.noHotelRoom')} —</option>
+              {allRooms.map(r => (
+                <option key={r.id} value={r.id}>{r.hotelName} — {r.roomType} (CHF {r.costPerNight}/night)</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className={labelCls}>{t('contract.hotelNights')}</label>
+            <div className="flex gap-2">
+              {NIGHT_LABELS.map(night => {
+                const key = `hotelNight${night.charAt(0).toUpperCase() + night.slice(1)}` as keyof AgreementFormDraft
+                return (
+                  <label key={night} className={`flex flex-col items-center text-xs cursor-pointer px-2 py-1 rounded border ${
+                    form[key] ? 'bg-gray-900 text-white border-gray-900' : 'border-gray-300'
+                  }`}>
+                    <input type="checkbox" className="sr-only" checked={form[key] as boolean}
+                      onChange={e => onChange(p => ({ ...p, [key]: e.target.checked }))} />
+                    {t(`night.${night}`)}
+                  </label>
+                )
+              })}
+            </div>
+          </div>
+          <div>
+            <label className={labelCls}>{t('contract.dinners')}</label>
+            <div className="flex gap-2">
+              {DINNER_LABELS.map(day => {
+                const key = `dinner${day.charAt(0).toUpperCase() + day.slice(1)}` as keyof AgreementFormDraft
+                return (
+                  <label key={day} className={`flex flex-col items-center text-xs cursor-pointer px-2 py-1 rounded border ${
+                    form[key] ? 'bg-gray-900 text-white border-gray-900' : 'border-gray-300'
+                  }`}>
+                    <input type="checkbox" className="sr-only" checked={form[key] as boolean}
+                      onChange={e => onChange(p => ({ ...p, [key]: e.target.checked }))} />
+                    {t(`night.${day}`)}
+                  </label>
+                )
+              })}
+            </div>
+          </div>
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input type="checkbox" checked={form.stadiumMeals}
+              onChange={e => onChange(p => ({ ...p, stadiumMeals: e.target.checked }))} />
+            {t('contract.stadiumMeals')}
+          </label>
+          <div>
+            <label className={labelCls}>{t('contract.notesToAthlete')}</label>
+            <textarea className={inputCls} rows={2} value={form.notes}
+              onChange={e => onChange(p => ({ ...p, notes: e.target.value }))} />
+          </div>
+
+          {/* Live cost preview */}
+          <div className="bg-gray-50 rounded p-3 text-sm">
+            <div className="flex justify-between font-semibold">
+              <span>{t('contract.totalCost')}</span>
+              <span>CHF {total.toLocaleString()}</span>
+            </div>
+          </div>
+
+          <div className="flex gap-2 justify-end pt-2 border-t">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm border rounded hover:bg-gray-50"
+            >
+              {t('common.cancel')}
+            </button>
+            <button
+              onClick={onSubmit}
+              disabled={isPending}
+              className="px-6 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 font-medium"
+            >
+              {isPending ? t('common.loading') : t('contract.validate')}
+            </button>
+          </div>
+          {error && (
+            <p className="text-xs text-red-600">{error.message || t('common.error')}</p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/web/pages/collaborator/athlete/types.ts
+++ b/src/web/pages/collaborator/athlete/types.ts
@@ -1,0 +1,100 @@
+import type { Hotel, HotelRoom, Application, Athlete, Event, EventCatalog, WaPerformance, Agreement } from '@shared/types'
+
+export interface HotelWithRooms extends Hotel {
+  rooms: HotelRoom[]
+}
+
+export type AgreementFormDraft = {
+  appearanceFee: number | ''
+  otherCompensation: number | ''
+  otherCompensationDesc: string
+  transport: number | ''
+  transportAirportHotel: boolean
+  transportHotelStadium: boolean
+  hotelRoomId: string
+  hotelNightTue: boolean
+  hotelNightWed: boolean
+  hotelNightThu: boolean
+  hotelNightFri: boolean
+  hotelNightSat: boolean
+  hotelNightSun: boolean
+  dinnerTue: boolean
+  dinnerWed: boolean
+  dinnerThu: boolean
+  dinnerFri: boolean
+  dinnerSat: boolean
+  dinnerSun: boolean
+  stadiumMeals: boolean
+  notes: string
+}
+
+export interface StaffUser {
+  id: string
+  firstName: string
+  lastName: string
+  role: string
+}
+
+export interface ApplicationRow extends Application {
+  athlete: Athlete
+  event: Event & { catalog: EventCatalog }
+  waPerformance: WaPerformance | null
+}
+
+export interface FieldDef {
+  key: string
+  label: string
+  type: 'text' | 'number' | 'date' | 'select' | 'checkbox' | 'textarea'
+  options?: { value: string; label: string }[]
+}
+
+export function defaultAgreement(existing?: Agreement): AgreementFormDraft {
+  if (existing) {
+    return {
+      appearanceFee: existing.appearanceFee,
+      otherCompensation: existing.otherCompensation,
+      otherCompensationDesc: existing.otherCompensationDesc ?? '',
+      transport: existing.transport,
+      transportAirportHotel: existing.transportAirportHotel,
+      transportHotelStadium: existing.transportHotelStadium,
+      hotelRoomId: existing.hotelRoomId ?? '',
+      hotelNightTue: existing.hotelNightTue,
+      hotelNightWed: existing.hotelNightWed,
+      hotelNightThu: existing.hotelNightThu,
+      hotelNightFri: existing.hotelNightFri,
+      hotelNightSat: existing.hotelNightSat,
+      hotelNightSun: existing.hotelNightSun,
+      dinnerTue: existing.dinnerTue,
+      dinnerWed: existing.dinnerWed,
+      dinnerThu: existing.dinnerThu,
+      dinnerFri: existing.dinnerFri,
+      dinnerSat: existing.dinnerSat,
+      dinnerSun: existing.dinnerSun,
+      stadiumMeals: existing.stadiumMeals,
+      notes: existing.notes ?? '',
+    }
+  }
+  return {
+    appearanceFee: '',
+    otherCompensation: '',
+    otherCompensationDesc: '',
+    transport: '',
+    transportAirportHotel: true,
+    transportHotelStadium: true,
+    hotelRoomId: '',
+    hotelNightTue: false,
+    hotelNightWed: false,
+    hotelNightThu: true,
+    hotelNightFri: true,
+    hotelNightSat: true,
+    hotelNightSun: false,
+    dinnerTue: false,
+    dinnerWed: false,
+    dinnerThu: true,
+    dinnerFri: true,
+    dinnerSat: true,
+    dinnerSun: false,
+    stadiumMeals: true,
+    notes: '',
+  }
+}

--- a/src/web/pages/collaborator/athlete/useAthleteData.ts
+++ b/src/web/pages/collaborator/athlete/useAthleteData.ts
@@ -1,0 +1,140 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { api } from '@web/lib/api'
+import { useAuth } from '@web/lib/auth'
+import type { AthleteDetail, NegotiationStatus } from '@shared/types'
+import type { HotelWithRooms, StaffUser, AgreementFormDraft } from './types'
+
+export function useAthleteData(id: string | undefined) {
+  const { data: athlete, isLoading } = useQuery<AthleteDetail>({
+    queryKey: ['athlete', id],
+    queryFn: () => api.get(`/api/v1/athletes/${id}`),
+    enabled: !!id,
+  })
+
+  const { data: hotels = [] } = useQuery<HotelWithRooms[]>({
+    queryKey: ['hotels'],
+    queryFn: () => api.get('/api/v1/hotels'),
+  })
+
+  const { data: staffUsers = [] } = useQuery<StaffUser[]>({
+    queryKey: ['staff-users'],
+    queryFn: () => api.get('/api/v1/users?role=collaborator,committee'),
+  })
+
+  const allRooms = hotels.flatMap(h => h.rooms.map(r => ({ ...r, hotelName: h.name })))
+
+  return { athlete, isLoading, hotels, staffUsers, allRooms }
+}
+
+export function useAthleteMutations(id: string | undefined) {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const { user } = useAuth()
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['athlete', id] })
+
+  const statusMutation = useMutation({
+    mutationFn: (status: NegotiationStatus) =>
+      api.patch<{ emailPreview?: { subject: string; body: string } }>(`/api/v1/athletes/${id}/negotiation-status`, { status }),
+    onSuccess: invalidate,
+  })
+
+  const agreementMutation = useMutation({
+    mutationFn: (data: AgreementFormDraft) =>
+      api.post<{ emailPreview?: { subject: string; body: string } }>(`/api/v1/athletes/${id}/agreements`, {
+        ...data,
+        appearanceFee: data.appearanceFee === '' ? 0 : data.appearanceFee,
+        otherCompensation: data.otherCompensation === '' ? 0 : data.otherCompensation,
+        transport: data.transport === '' ? 0 : data.transport,
+        hotelRoomId: data.hotelRoomId || undefined,
+      }),
+    onSuccess: invalidate,
+  })
+
+  const noteMutation = useMutation({
+    mutationFn: (data: { type: string; content: string }) =>
+      api.post(`/api/v1/athletes/${id}/interactions`, data),
+    onSuccess: invalidate,
+  })
+
+  const internalNotesMutation = useMutation({
+    mutationFn: (notes: string) =>
+      api.patch(`/api/v1/athletes/${id}`, { internalNotes: notes }),
+    onSuccess: invalidate,
+  })
+
+  const participationMutation = useMutation({
+    mutationFn: ({ appId, status }: { appId: string; status: string }) =>
+      api.patch(`/api/v1/applications/${appId}/participation-status`, { participationStatus: status }),
+    onSuccess: invalidate,
+  })
+
+  const scoreMutation = useMutation({
+    mutationFn: (appId: string) => api.post(`/api/v1/applications/${appId}/score`, {}),
+    onSuccess: invalidate,
+  })
+
+  const athleteUpdateMutation = useMutation({
+    mutationFn: (data: Record<string, unknown>) =>
+      api.patch(`/api/v1/athletes/${id}`, data),
+    onSuccess: invalidate,
+  })
+
+  const waPerfMutation = useMutation({
+    mutationFn: (data: { athleteId: string; eventId: string; personalBest?: number; seasonBest?: number; worldRanking?: number }) =>
+      api.post('/api/v1/wa-performance', data),
+    onSuccess: invalidate,
+  })
+
+  const waFetchMutation = useMutation({
+    mutationFn: () => api.post<{ fetched: number; matched: number; errors: string[] }>(`/api/v1/wa-performance/fetch/${id}`),
+    onSuccess: invalidate,
+  })
+
+  const counterOfferMutation = useMutation({
+    mutationFn: async (text: string) => {
+      await api.post(`/api/v1/athletes/${id}/interactions`, { type: 'counter_offer', content: text })
+      return api.patch<{ emailPreview?: { subject: string; body: string } }>(`/api/v1/athletes/${id}/negotiation-status`, { status: 'counter_offer_sent' })
+    },
+    onSuccess: invalidate,
+  })
+
+  const freeMessageMutation = useMutation({
+    mutationFn: (text: string) =>
+      api.post(`/api/v1/athletes/${id}/interactions`, { type: 'note', content: text }),
+    onSuccess: invalidate,
+  })
+
+  const archiveMutation = useMutation({
+    mutationFn: () => api.delete(`/api/v1/athletes/${id}`),
+    onSuccess: () => navigate(
+      user?.role === 'committee' ? '/committee/candidates' :
+      user?.role === 'manager' ? '/manager/portal' :
+      user?.role === 'athlete' ? '/athlete/portal' :
+      '/collaborator/candidates'
+    ),
+  })
+
+  return {
+    statusMutation,
+    agreementMutation,
+    noteMutation,
+    internalNotesMutation,
+    participationMutation,
+    scoreMutation,
+    athleteUpdateMutation,
+    waPerfMutation,
+    waFetchMutation,
+    counterOfferMutation,
+    freeMessageMutation,
+    archiveMutation,
+  }
+}
+
+export function useEmailQuery(emailId: string | null) {
+  return useQuery<{ subject: string; body: string; htmlBody?: string; to: string; sentAt: string }>({
+    queryKey: ['email', emailId],
+    queryFn: () => api.get(`/api/v1/emails/${emailId}`),
+    enabled: !!emailId,
+  })
+}


### PR DESCRIPTION
## Summary

- Splits the 1812-line `AthletePage.tsx` monolith into 8 focused files under `athlete/`
- Main orchestrator reduced to ~493 lines
- Extracts: types, custom hooks, reusable components, banner row, modals, personal tab, negotiation tab
- No functional changes — pure structural refactor

## File breakdown

| File | Lines | Purpose |
|------|-------|---------|
| `types.ts` | 100 | Shared types + `defaultAgreement` helper |
| `useAthleteData.ts` | 140 | All queries and mutations |
| `components.tsx` | 252 | CollapsibleSection, FieldReadOnly, AthleteFieldEditor, etc. |
| `BannerEventRow.tsx` | 318 | Event rows, scoring popup, cost popup |
| `modals.tsx` | 390 | All modal dialogs |
| `PersonalTab.tsx` | 184 | Personal data tab |
| `NegotiationTab.tsx` | 148 | Agreement/timeline tab |
| `AthletePage.tsx` | 493 | Thin orchestrator |

## Test plan

- [x] `npm run check` passes (264 tests, TypeScript clean)
- [ ] Manual: navigate to athlete detail page, verify banner renders correctly
- [ ] Manual: switch between Personal and Negotiation tabs
- [ ] Manual: test agreement form modal opens and submits
- [ ] Manual: test status transitions and confirmation dialogs

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)