### PR TITLE
fix: WA auto-fetch ne s'exécutait pas lors de l'inscription

### DIFF
--- a/src/api/routes/athletes.ts
+++ b/src/api/routes/athletes.ts
@@ -95,8 +95,11 @@ athletes.post('/', zValidator('json', athleteRegistrationSchema), async (c) => {
   await recalculateAthleteEstimatedCost(db, athleteId)
 
   // Auto-fetch WA performance data if profile URL provided
+  // waitUntil keeps the Worker alive after the response is sent
   if (data.waProfileUrl) {
-    fetchAndUpsertWaData(db, athleteId, upsertWaPerformance).catch(() => {})
+    c.executionCtx.waitUntil(
+      fetchAndUpsertWaData(db, athleteId, upsertWaPerformance).catch(() => {})
+    )
   }
 
   // If email provided, create a user record so the athlete can log in later
@@ -237,8 +240,11 @@ athletes.post('/batch', requireAuth('manager'), zValidator('json', batchAthleteR
     await recalculateAthleteEstimatedCost(db, athleteId)
 
     // Auto-fetch WA performance data if profile URL provided
+    // waitUntil keeps the Worker alive after the response is sent
     if (data.waProfileUrl) {
-      fetchAndUpsertWaData(db, athleteId, upsertWaPerformance).catch(() => {})
+      c.executionCtx.waitUntil(
+        fetchAndUpsertWaData(db, athleteId, upsertWaPerformance).catch(() => {})
+      )
     }
 
     results.push({ athleteId, applicationIds, firstName: data.firstName, lastName: data.lastName, eventIds: validEventIds })


### PR DESCRIPTION
Fix the bug where WA profile data was not fetched during athlete registration.

In Cloudflare Workers, fire-and-forget promises are killed when the response is returned. Use `c.executionCtx.waitUntil()` to keep the Worker alive until the WA fetch completes.

Closes #26

Generated with [Claude Code](https://claude.ai/code)