### PR TITLE
fix: correct Personal Data save errors for collaborator athlete page

### DIFF
--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -21,7 +21,20 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: res.statusText })) as { error?: unknown }
-    const errorMessage = typeof body.error === 'string' ? body.error : res.statusText
+    let errorMessage: string
+    if (typeof body.error === 'string') {
+      errorMessage = body.error || res.statusText || 'Request failed'
+    } else if (body.error && typeof body.error === 'object') {
+      const issues = (body.error as Record<string, unknown>).issues
+      if (Array.isArray(issues) && issues.length > 0) {
+        const first = issues[0] as Record<string, unknown>
+        errorMessage = typeof first.message === 'string' ? first.message : 'Validation error'
+      } else {
+        errorMessage = res.statusText || 'Request failed'
+      }
+    } else {
+      errorMessage = res.statusText || 'Request failed'
+    }
     throw new ApiError(res.status, errorMessage)
   }
 

--- a/src/web/pages/collaborator/athlete/PersonalTab.tsx
+++ b/src/web/pages/collaborator/athlete/PersonalTab.tsx
@@ -11,7 +11,7 @@ export function PersonalTab({ athlete, isStaff, isAthleteOrManager, staffUsers, 
   isAthleteOrManager: boolean
   staffUsers: StaffUser[]
   mutations: {
-    athleteUpdate: { mutate: (data: Record<string, unknown>) => void; isPending: boolean; error: Error | null }
+    athleteUpdate: { mutate: (data: Record<string, unknown>, options?: { onSuccess?: () => void }) => void; isPending: boolean; error: Error | null }
     internalNotes: { mutate: (notes: string) => void; isPending: boolean }
   }
 }) {
@@ -104,7 +104,9 @@ export function PersonalTab({ athlete, isStaff, isAthleteOrManager, staffUsers, 
         <AthleteFieldEditor
           athlete={athlete}
           fields={fields}
-          onSave={(data) => { mutations.athleteUpdate.mutate(data); setEditingSection(null) }}
+          onSave={(data) => {
+            mutations.athleteUpdate.mutate(data, { onSuccess: () => setEditingSection(null) })
+          }}
           isPending={mutations.athleteUpdate.isPending}
           error={mutations.athleteUpdate.error}
           t={t}

--- a/src/web/pages/collaborator/athlete/components.tsx
+++ b/src/web/pages/collaborator/athlete/components.tsx
@@ -115,7 +115,12 @@ export function AthleteFieldEditor({ athlete, fields, onSave, isPending, error, 
         </div>
       ))}
       <button
-        onClick={() => onSave(form)}
+        onClick={() => {
+          const cleaned = Object.fromEntries(
+            Object.entries(form).map(([k, v]) => [k, v === '' ? null : v])
+          )
+          onSave(cleaned)
+        }}
         disabled={isPending}
         className="mt-2 text-xs bg-gray-900 text-white px-3 py-1 rounded hover:bg-gray-800 disabled:opacity-50"
       >


### PR DESCRIPTION
Fixes #4

Three issues caused save to silently fail or show unhelpful errors in the Personal Data section:

1. **Empty string sent for nullable enum fields** — When `athlete.paymentMethod` is null, the form initialised the select to `''` which fails Zod validation. AthleteFieldEditor now converts `''` → `null` before sending.

2. **Editor closed before mutation resolved** — setEditingSection(null) was called immediately, hiding any error. Editor now only closes on success.

3. **Opaque error messages** — api.ts fell back to `res.statusText` (empty on Cloudflare Workers HTTP/2) when the error was a Zod object. The first Zod issue message is now extracted and shown.

Generated with [Claude Code](https://claude.ai/code)