### PR TITLE
fix: replace Back button with Logout for athlete role

### DIFF
--- a/src/web/pages/collaborator/AthletePage.tsx
+++ b/src/web/pages/collaborator/AthletePage.tsx
@@ -24,7 +24,7 @@ import {
 export default function AthletePage() {
   const { t } = useTranslation()
   const { id } = useParams<{ id: string }>()
-  const { user } = useAuth()
+  const { user, logout } = useAuth()
   const navigate = useNavigate()
 
   // ── Data ───────────────────────────────���──────────────────────────────
@@ -136,13 +136,20 @@ export default function AthletePage() {
               >
                 ← {t('common.back')}
               </button>
-            ) : (
+            ) : user?.role === 'manager' ? (
               <Link
-                to={user?.role === 'manager' ? '/manager/portal' : '/athlete/portal'}
+                to="/manager/portal"
                 className="text-sm text-gray-400 hover:text-gray-600"
               >
                 ← {t('common.back')}
               </Link>
+            ) : (
+              <button
+                onClick={() => logout()}
+                className="text-sm text-gray-400 hover:text-gray-600"
+              >
+                {t('auth.logout')}
+              </button>
             )}
             <LanguageSwitcher />
           </div>


### PR DESCRIPTION
Pressing ← Back on the athlete page linked to `/athlete/portal`, which immediately redirects back to the athlete page — trapping the athlete in a loop. For role `athlete`, replace that link with a Logout button. Managers keep their ← Back link to `/manager/portal`.

Closes #64

Generated with [Claude Code](https://claude.ai/code)