### PR TITLE
fix: popups coût et scoring flottants au-dessus de la page (portail React)

### DIFF
--- a/src/web/pages/collaborator/CandidatesPage.tsx
+++ b/src/web/pages/collaborator/CandidatesPage.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { Link, useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -268,8 +269,10 @@ function CandidateRow({
   userRole: string | undefined
 }) {
   const { t } = useTranslation()
-  const [showCostPopup, setShowCostPopup] = useState(false)
-  const [showScoringPopup, setShowScoringPopup] = useState(false)
+  const costBtnRef = useRef<HTMLButtonElement>(null)
+  const scoreBtnRef = useRef<HTMLButtonElement>(null)
+  const [costRect, setCostRect] = useState<DOMRect | null>(null)
+  const [scoreRect, setScoreRect] = useState<DOMRect | null>(null)
 
   const pb = app.waPerformance?.personalBest ?? app.personalBest
   const sb = app.waPerformance?.seasonBest ?? app.seasonBest
@@ -348,30 +351,31 @@ function CandidateRow({
 
       {/* Cost with hover popup */}
       <td className="px-3 py-2.5 font-mono text-xs">
-        <div className="relative inline-block">
-          <button
-            className="text-left hover:text-blue-700 cursor-default"
-            onMouseEnter={() => setShowCostPopup(true)}
-            onMouseLeave={() => setShowCostPopup(false)}
-          >
-            {hasOffer && latestOfferCost != null ? (
-              `CHF ${latestOfferCost.toLocaleString()}`
-            ) : app.athlete.estTotal > 0 ? (
-              <span className="text-gray-400">CHF {app.athlete.estTotal.toLocaleString()}</span>
-            ) : (
-              <span className="text-gray-400">—</span>
-            )}
-          </button>
-          {showCostPopup && (
-            <CostPopup
-              athlete={athleteDetail}
-              latestAgreement={app.latestAgreement ?? undefined}
-              costMode={costMode}
-              allRooms={allRooms}
-              t={t}
-            />
+        <button
+          ref={costBtnRef}
+          className="text-left hover:text-blue-700 cursor-default"
+          onMouseEnter={() => { if (costBtnRef.current) setCostRect(costBtnRef.current.getBoundingClientRect()) }}
+          onMouseLeave={() => setCostRect(null)}
+        >
+          {hasOffer && latestOfferCost != null ? (
+            `CHF ${latestOfferCost.toLocaleString()}`
+          ) : app.athlete.estTotal > 0 ? (
+            <span className="text-gray-400">CHF {app.athlete.estTotal.toLocaleString()}</span>
+          ) : (
+            <span className="text-gray-400">—</span>
           )}
-        </div>
+        </button>
+        {costRect && createPortal(
+          <CostPopup
+            athlete={athleteDetail}
+            latestAgreement={app.latestAgreement ?? undefined}
+            costMode={costMode}
+            allRooms={allRooms}
+            t={t}
+            style={{ position: 'fixed', top: costRect.bottom + 4, left: Math.max(0, costRect.right - 256), zIndex: 9999 }}
+          />,
+          document.body
+        )}
       </td>
 
       {/* Event */}
@@ -393,23 +397,26 @@ function CandidateRow({
       {/* Scoring with hover popup */}
       <td className="px-3 py-2.5">
         {app.score != null ? (
-          <div className="relative inline-block">
+          <>
             <button
+              ref={scoreBtnRef}
               className="font-mono text-xs font-medium hover:text-blue-700 cursor-default"
-              onMouseEnter={() => setShowScoringPopup(true)}
-              onMouseLeave={() => setShowScoringPopup(false)}
+              onMouseEnter={() => { if (scoreBtnRef.current) setScoreRect(scoreBtnRef.current.getBoundingClientRect()) }}
+              onMouseLeave={() => setScoreRect(null)}
             >
               {(app.score * 100).toFixed(0)}
             </button>
-            {showScoringPopup && edition && (
+            {scoreRect && edition && createPortal(
               <ScoringPopup
                 app={appForScoring}
                 athlete={athleteDetail}
                 edition={edition}
                 t={t}
-              />
+                style={{ position: 'fixed', top: scoreRect.bottom + 4, left: scoreRect.left, zIndex: 9999 }}
+              />,
+              document.body
             )}
-          </div>
+          </>
         ) : (
           '—'
         )}

--- a/src/web/pages/collaborator/athlete/BannerEventRow.tsx
+++ b/src/web/pages/collaborator/athlete/BannerEventRow.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import React, { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { api } from '@web/lib/api'
 import { computeScore } from '@shared/scoring'
@@ -9,11 +9,12 @@ import type { ApplicationRow } from './types'
 
 // ── ScoringPopup ────────────────────────────────────────────────────────────
 
-export function ScoringPopup({ app, athlete, edition, t }: {
+export function ScoringPopup({ app, athlete, edition, t, style }: {
   app: ApplicationForAthlete
   athlete: AthleteDetail
   edition: EditionCosts
   t: (key: string, opts?: Record<string, unknown>) => string
+  style?: React.CSSProperties
 }) {
   const wp = app.waPerformance
   if (!wp || wp.personalBest == null || !edition) return null
@@ -33,8 +34,10 @@ export function ScoringPopup({ app, athlete, edition, t }: {
     eapMinima: app.event.eapMinima,
   }, edition)
 
+  const posStyle: React.CSSProperties = style ?? { position: 'absolute', zIndex: 20, left: 0, top: '1.5rem' }
+
   return (
-    <div className="absolute z-20 left-0 top-6 bg-white border rounded-lg shadow-lg p-3 text-xs w-52">
+    <div className="bg-white border rounded-lg shadow-lg p-3 text-xs w-52" style={posStyle}>
       <p className="font-semibold mb-2">{t('selection.scoringBreakdown')}</p>
       <div className="space-y-1 text-gray-600">
         <div className="flex justify-between">
@@ -282,12 +285,13 @@ export function BannerEventRow({ app, athlete, edition, isStaff, onParticipation
 
 // ── CostPopup ───────────────────────────────────────────────────────────────
 
-export function CostPopup({ athlete, latestAgreement, costMode, allRooms, t }: {
+export function CostPopup({ athlete, latestAgreement, costMode, allRooms, t, style }: {
   athlete: AthleteDetail
   latestAgreement: Agreement | undefined
   costMode: string
   allRooms: { id: string; costPerNight: number; dinnerCost: number }[]
   t: (key: string) => string
+  style?: React.CSSProperties
 }) {
   const room = latestAgreement ? allRooms.find(r => r.id === latestAgreement.hotelRoomId) : undefined
   const nightCount = latestAgreement
@@ -302,8 +306,10 @@ export function CostPopup({ athlete, latestAgreement, costMode, allRooms, t }: {
   const transportAHCost = latestAgreement?.transportAirportHotel ? (athlete.edition?.transportAirportHotelCost ?? 0) : 0
   const transportHSCost = latestAgreement?.transportHotelStadium ? (athlete.edition?.transportHotelStadiumCost ?? 0) : 0
 
+  const posStyle: React.CSSProperties = style ?? { position: 'absolute', zIndex: 20, right: 0, top: '1.5rem' }
+
   return (
-    <div className="absolute z-20 right-0 top-6 bg-white border rounded-lg shadow-lg p-3 text-xs w-64">
+    <div className="bg-white border rounded-lg shadow-lg p-3 text-xs w-64" style={posStyle}>
       {costMode === 'confirmed' && !latestAgreement ? (
         <p className="text-green-700 italic">{t('selection.acceptedAtMeeting')}</p>
       ) : costMode !== 'estimated' && latestAgreement ? (


### PR DESCRIPTION
Fixes #73

Les popups de coût et scoring dans l'écran de sélection des candidats sont maintenant rendus via `createPortal` avec `position: fixed`, évitant qu'ils soient masqués par le conteneur `overflow-x-auto` du tableau.

Generated with [Claude Code](https://claude.ai/code)