### PR TITLE
feat: move WA discipline mapping into event catalog

### DIFF
--- a/src/api/db/migrations/0007_wa_fields_in_catalog.sql
+++ b/src/api/db/migrations/0007_wa_fields_in_catalog.sql
@@ -1,0 +1,4 @@
+-- Move WA discipline mapping into event_catalog table
+ALTER TABLE event_catalog ADD COLUMN wa_name TEXT;
+ALTER TABLE event_catalog ADD COLUMN wa_ranking_slug TEXT;
+DROP TABLE IF EXISTS wa_discipline_map;

--- a/src/api/db/schema.ts
+++ b/src/api/db/schema.ts
@@ -36,6 +36,8 @@ export const eventCatalog = sqliteTable('event_catalog', {
   name: text('name').notNull(),
   discipline: text('discipline').notNull(),
   gender: text('gender').notNull(),
+  waName: text('wa_name'),
+  waRankingSlug: text('wa_ranking_slug'),
 })
 
 // ── Event ─────────────────────────────────────────────────────────────────────
@@ -252,15 +254,6 @@ export const emailLog = sqliteTable('email_log', {
   lang: text('lang').notNull(),
   sentAt: text('sent_at').notNull().default(sql`(datetime('now'))`),
   relatedAthleteId: text('related_athlete_id').references(() => athlete.id),
-})
-
-// ── WA Discipline Mapping ────────────────────────────────────────────────────
-
-export const waDisciplineMap = sqliteTable('wa_discipline_map', {
-  id: id(),
-  waName: text('wa_name').notNull(),
-  waRankingSlug: text('wa_ranking_slug'),
-  catalogName: text('catalog_name').notNull(),
 })
 
 // ── WA Performance ────────────────────────────────────────────────────────────

--- a/src/api/routes/editions.ts
+++ b/src/api/routes/editions.ts
@@ -3,7 +3,7 @@ import { zValidator } from '@hono/zod-validator'
 import { eq } from 'drizzle-orm'
 import * as schema from '../db/schema'
 import { requireAuth } from '../middleware/auth'
-import { editionConfigSchema, costTierConfigsSchema, costDistanceConfigsSchema, waDisciplineMapSchema } from '@shared/validation'
+import { editionConfigSchema, costTierConfigsSchema, costDistanceConfigsSchema } from '@shared/validation'
 import { recalculateAllAthletesForEdition } from '../services/costEstimation'
 import type { Env } from '../index'
 
@@ -168,38 +168,6 @@ app.put('/:id/cost-distance-configs', requireAuth('committee'), zValidator('json
     if (b.distanceMax == null) return -1
     return a.distanceMax - b.distanceMax
   }))
-})
-
-// ── WA Discipline Mapping CRUD (committee only) ─────────────────────────────
-
-app.get('/wa-discipline-map', requireAuth('committee'), async (c) => {
-  const db = c.get('db')
-  const rows = await db.select().from(schema.waDisciplineMap)
-  return c.json(rows)
-})
-
-app.post('/wa-discipline-map', requireAuth('committee'), zValidator('json', waDisciplineMapSchema), async (c) => {
-  const db = c.get('db')
-  const data = c.req.valid('json')
-
-  const id = crypto.randomUUID()
-  await db.insert(schema.waDisciplineMap).values({
-    id,
-    waName: data.waName,
-    waRankingSlug: data.waRankingSlug ?? null,
-    catalogName: data.catalogName,
-  })
-
-  const rows = await db.select().from(schema.waDisciplineMap).where(eq(schema.waDisciplineMap.id, id))
-  return c.json(rows[0], 201)
-})
-
-app.delete('/wa-discipline-map/:id', requireAuth('committee'), async (c) => {
-  const db = c.get('db')
-  const { id } = c.req.param()
-
-  await db.delete(schema.waDisciplineMap).where(eq(schema.waDisciplineMap.id, id))
-  return c.json({ success: true })
 })
 
 export default app

--- a/src/api/routes/event-catalog.ts
+++ b/src/api/routes/event-catalog.ts
@@ -27,6 +27,8 @@ app.post('/', requireAuth('committee'), zValidator('json', eventCatalogSchema), 
     name: data.name,
     discipline: data.discipline,
     gender: data.gender,
+    waName: data.waName ?? null,
+    waRankingSlug: data.waRankingSlug ?? null,
   })
 
   const created = await db.select().from(schema.eventCatalog).where(eq(schema.eventCatalog.id, id)).limit(1)

--- a/src/api/services/wa-scraper.ts
+++ b/src/api/services/wa-scraper.ts
@@ -2,7 +2,7 @@
 // Fetches an athlete's WA profile page, extracts __NEXT_DATA__ JSON,
 // and parses PB, SB, and world ranking per discipline.
 
-import { eq } from 'drizzle-orm'
+import { and, eq, isNotNull } from 'drizzle-orm'
 import * as schema from '../db/schema'
 import type { Db } from '../lib/helpers'
 
@@ -25,38 +25,18 @@ export interface DisciplineMapping {
   waName: string
   waRankingSlug: string | null
   catalogName: string
+  isField: boolean
 }
-
-// ── Default Seed Data ──────────────────────────────────────���─────────────────
-
-export const DEFAULT_DISCIPLINE_MAPPINGS: DisciplineMapping[] = [
-  { waName: '100 Metres', waRankingSlug: '100m', catalogName: '100m' },
-  { waName: '200 Metres', waRankingSlug: '200m', catalogName: '200m' },
-  { waName: '400 Metres', waRankingSlug: '400m', catalogName: '400m' },
-  { waName: '400 Metres Hurdles', waRankingSlug: '400mh', catalogName: '400mH' },
-  { waName: '800 Metres', waRankingSlug: '800m', catalogName: '800m' },
-  { waName: '1500 Metres', waRankingSlug: '1500m', catalogName: '1500m' },
-  { waName: '5000 Metres', waRankingSlug: '5000m', catalogName: '5000m' },
-  { waName: 'High Jump', waRankingSlug: 'high-jump', catalogName: 'High Jump' },
-  { waName: 'Long Jump', waRankingSlug: 'long-jump', catalogName: 'Long Jump' },
-  { waName: 'Pole Vault', waRankingSlug: 'pole-vault', catalogName: 'Pole Vault' },
-  { waName: 'Shot Put', waRankingSlug: 'shot-put', catalogName: 'Shot Put' },
-]
-
-// Track disciplines use 'Course' (lower is better), field uses 'Concours' (higher is better)
-const FIELD_EVENTS = new Set(['High Jump', 'Long Jump', 'Pole Vault', 'Shot Put'])
 
 // ── Mark Parsing ─────────────────────────────────────────────────────────────
 
 /**
  * Parse a WA mark string into a numeric value.
- * - Track events: stored as seconds (e.g. "9.80" → 9.80, "3:26.00" → 206.00)
- * - Field events: stored as centimeters (e.g. "2.35" → 235)
+ * - Track events (isField=false): stored as seconds (e.g. "9.80" → 9.80, "3:26.00" → 206.00)
+ * - Field events (isField=true): stored as centimeters (e.g. "2.35" → 235)
  */
-export function parseMark(mark: string, catalogName: string): number | null {
+export function parseMark(mark: string, isField: boolean): number | null {
   if (!mark || mark === '') return null
-
-  const isField = FIELD_EVENTS.has(catalogName)
 
   // Handle mm:ss.cc format (e.g. "3:26.00")
   const colonMatch = mark.match(/^(\d+):(\d+(?:\.\d+)?)$/)
@@ -93,18 +73,18 @@ interface WaRanking {
 
 /**
  * Fetch a WA profile page and extract structured performance data.
- * Discipline mapping is loaded from DB and passed in.
+ * Discipline mappings are built from the event catalog (gender-filtered).
  */
 export async function scrapeWaProfile(
   waProfileUrl: string,
   mappings: DisciplineMapping[],
 ): Promise<WaScrapeResult> {
-  // Build lookup maps from DB mappings
-  const nameMap = new Map<string, string>() // WA name → catalog name
-  const slugMap = new Map<string, string>() // WA ranking slug → catalog name
+  // Build lookup maps from mappings
+  const nameMap = new Map<string, { catalogName: string; isField: boolean }>()
+  const slugMap = new Map<string, { catalogName: string; isField: boolean }>()
   for (const m of mappings) {
-    nameMap.set(m.waName, m.catalogName)
-    if (m.waRankingSlug) slugMap.set(m.waRankingSlug, m.catalogName)
+    nameMap.set(m.waName, { catalogName: m.catalogName, isField: m.isField })
+    if (m.waRankingSlug) slugMap.set(m.waRankingSlug, { catalogName: m.catalogName, isField: m.isField })
   }
 
   const controller = new AbortController()
@@ -153,11 +133,11 @@ export async function scrapeWaProfile(
   const pbResults: WaResult[] = competitor.personalBests?.results ?? []
   for (const r of pbResults) {
     if (r.indoor || r.notLegal) continue
-    const catalogName = nameMap.get(r.discipline)
-    if (!catalogName) continue
-    const value = parseMark(r.mark, catalogName)
+    const info = nameMap.get(r.discipline)
+    if (!info) continue
+    const value = parseMark(r.mark, info.isField)
     if (value != null) {
-      ensureEntry(catalogName).personalBest = value
+      ensureEntry(info.catalogName).personalBest = value
     }
   }
 
@@ -165,26 +145,26 @@ export async function scrapeWaProfile(
   const sbResults: WaResult[] = competitor.seasonsBests?.results ?? []
   for (const r of sbResults) {
     if (r.indoor || r.notLegal) continue
-    const catalogName = nameMap.get(r.discipline)
-    if (!catalogName) continue
-    const value = parseMark(r.mark, catalogName)
+    const info = nameMap.get(r.discipline)
+    if (!info) continue
+    const value = parseMark(r.mark, info.isField)
     if (value != null) {
-      ensureEntry(catalogName).seasonBest = value
+      ensureEntry(info.catalogName).seasonBest = value
     }
   }
 
   // Parse world rankings
   const rankings: WaRanking[] = competitor.worldRankings?.current ?? []
   for (const r of rankings) {
-    const catalogName = slugMap.get(r.urlSlug)
-    if (!catalogName) continue
-    ensureEntry(catalogName).worldRanking = r.place
+    const info = slugMap.get(r.urlSlug)
+    if (!info) continue
+    ensureEntry(info.catalogName).worldRanking = r.place
   }
 
   // Convert map to array
   const performances: WaScrapedPerformance[] = []
   for (const [catalogName, perf] of perfMap) {
-    const waDiscipline = [...nameMap.entries()].find(([, v]) => v === catalogName)?.[0] ?? catalogName
+    const waDiscipline = [...nameMap.entries()].find(([, v]) => v.catalogName === catalogName)?.[0] ?? catalogName
     performances.push({
       waDiscipline,
       catalogName,
@@ -208,15 +188,20 @@ export async function fetchAndUpsertWaData(
 
   if (!athlete.waProfileUrl) throw new Error('No WA profile URL')
 
-  // Load discipline mappings from DB
-  const mappingRows = await db.select().from(schema.waDisciplineMap)
-  const mappings: DisciplineMapping[] = mappingRows.map(r => ({
-    waName: r.waName,
-    waRankingSlug: r.waRankingSlug,
-    catalogName: r.catalogName,
+  // Load discipline mappings from event catalog, filtered by athlete gender
+  const catalogRows = await db
+    .select()
+    .from(schema.eventCatalog)
+    .where(and(isNotNull(schema.eventCatalog.waName), eq(schema.eventCatalog.gender, athlete.gender)))
+
+  const mappings: DisciplineMapping[] = catalogRows.map(r => ({
+    waName: r.waName!,
+    waRankingSlug: r.waRankingSlug ?? null,
+    catalogName: r.name,
+    isField: r.discipline === 'Concours',
   }))
 
-  if (mappings.length === 0) throw new Error('No discipline mappings configured')
+  if (mappings.length === 0) throw new Error('No WA discipline mappings configured in event catalog')
 
   const result = await scrapeWaProfile(athlete.waProfileUrl, mappings)
   const fetched = result.performances.length
@@ -241,9 +226,8 @@ export async function fetchAndUpsertWaData(
       continue
     }
 
-    const eventMatch = events.find(
-      e => e.catalog.name === perf.catalogName && e.catalog.gender === athlete.gender
-    )
+    // Catalog names are already gender-specific (loaded per athlete gender above)
+    const eventMatch = events.find(e => e.catalog.name === perf.catalogName)
 
     if (!eventMatch) continue
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -80,6 +80,8 @@ export interface EventCatalog {
   name: string
   discipline: string
   gender: Gender
+  waName: string | null
+  waRankingSlug: string | null
 }
 
 export interface Event {

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -254,6 +254,8 @@ export const eventCatalogSchema = z.object({
   name: z.string().min(1),
   discipline: z.enum(['Course', 'Concours']),
   gender: z.enum(['M', 'F']),
+  waName: z.string().min(1).nullable().optional(),
+  waRankingSlug: z.string().nullable().optional(),
 })
 
 // ── Country ───────────────────────────────────────────────────────────────────
@@ -303,15 +305,7 @@ export const waPerformanceSchema = z.object({
   worldRanking: z.number().int().min(1).optional(),
 })
 
-// ── WA Discipline Map ────────────────────────────────────────────────────────
-
-export const waDisciplineMapSchema = z.object({
-  waName: z.string().min(1),
-  waRankingSlug: z.string().optional(),
-  catalogName: z.string().min(1),
-})
-
-// ���─ Interaction ──────────────────────────────────────────────────────────────
+// ── Interaction ──────────────────────────────────────────────────────────────
 
 export const interactionSchema = z.object({
   type: z.enum(['email', 'call', 'note', 'counter_offer', 'status_change', 'agreement']),

--- a/src/web/pages/committee/EditionConfigPage.tsx
+++ b/src/web/pages/committee/EditionConfigPage.tsx
@@ -121,9 +121,6 @@ export default function EditionConfigPage() {
 
       {/* Estimated cost configuration */}
       <CostConfigSection edition={edition} costConfigs={costConfigs ?? { tierConfigs: [], distanceConfigs: [] }} />
-
-      {/* WA Discipline Mapping */}
-      <WaDisciplineMapSection />
     </div>
   )
 }
@@ -386,127 +383,6 @@ function CostConfigSection({ edition, costConfigs }: { edition: Edition; costCon
           </button>
           {distSaved && <span className="text-sm text-green-600">{t('admin.saved')}</span>}
           {distMutation.isError && <span className="text-sm text-red-600">{(distMutation.error as Error)?.message || t('common.error')}</span>}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-// ── WA Discipline Mapping Section ────────────────────────────────────────────
-
-interface WaMapping {
-  id: string
-  waName: string
-  waRankingSlug: string | null
-  catalogName: string
-}
-
-function WaDisciplineMapSection() {
-  const { t } = useTranslation()
-  const queryClient = useQueryClient()
-
-  const { data: mappings = [] } = useQuery<WaMapping[]>({
-    queryKey: ['wa-discipline-map'],
-    queryFn: () => api.get('/api/v1/editions/wa-discipline-map'),
-  })
-
-  const [newRow, setNewRow] = useState({ waName: '', waRankingSlug: '', catalogName: '' })
-
-  const addMutation = useMutation({
-    mutationFn: (data: { waName: string; waRankingSlug: string; catalogName: string }) =>
-      api.post('/api/v1/editions/wa-discipline-map', data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['wa-discipline-map'] })
-      setNewRow({ waName: '', waRankingSlug: '', catalogName: '' })
-    },
-  })
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.delete(`/api/v1/editions/wa-discipline-map/${id}`),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['wa-discipline-map'] }),
-  })
-
-  const handleAdd = () => {
-    if (!newRow.waName || !newRow.catalogName) return
-    addMutation.mutate(newRow)
-  }
-
-  return (
-    <div className="space-y-4">
-      <h2 className="text-base font-bold">{t('admin.waDisciplineMap')}</h2>
-      <p className="text-xs text-gray-500">{t('admin.waDisciplineMapHint')}</p>
-
-      <div className="bg-white rounded-lg border p-4">
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b bg-gray-50 text-xs text-gray-500">
-                <th className="px-2 py-2 text-left font-medium">{t('admin.waName')}</th>
-                <th className="px-2 py-2 text-left font-medium">{t('admin.waRankingSlug')}</th>
-                <th className="px-2 py-2 text-left font-medium">{t('admin.catalogName')}</th>
-                <th className="px-2 py-2"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {mappings.map((m) => (
-                <tr key={m.id} className="border-b">
-                  <td className="px-2 py-1.5 text-sm">{m.waName}</td>
-                  <td className="px-2 py-1.5 text-sm text-gray-500">{m.waRankingSlug ?? '—'}</td>
-                  <td className="px-2 py-1.5 text-sm">{m.catalogName}</td>
-                  <td className="px-2 py-1.5">
-                    <button
-                      type="button"
-                      onClick={() => { if (confirm(t('common.confirmDelete'))) deleteMutation.mutate(m.id) }}
-                      disabled={deleteMutation.isPending}
-                      className="text-xs text-red-600 hover:text-red-800"
-                    >
-                      ×
-                    </button>
-                  </td>
-                </tr>
-              ))}
-              {/* Add row */}
-              <tr className="border-b bg-gray-50/50">
-                <td className="px-2 py-1.5">
-                  <input
-                    type="text"
-                    value={newRow.waName}
-                    onChange={(e) => setNewRow(r => ({ ...r, waName: e.target.value }))}
-                    placeholder="e.g. 100 Metres"
-                    className="w-full px-1.5 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-900"
-                  />
-                </td>
-                <td className="px-2 py-1.5">
-                  <input
-                    type="text"
-                    value={newRow.waRankingSlug}
-                    onChange={(e) => setNewRow(r => ({ ...r, waRankingSlug: e.target.value }))}
-                    placeholder="e.g. 100m"
-                    className="w-full px-1.5 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-900"
-                  />
-                </td>
-                <td className="px-2 py-1.5">
-                  <input
-                    type="text"
-                    value={newRow.catalogName}
-                    onChange={(e) => setNewRow(r => ({ ...r, catalogName: e.target.value }))}
-                    placeholder="e.g. 100m"
-                    className="w-full px-1.5 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-900"
-                  />
-                </td>
-                <td className="px-2 py-1.5">
-                  <button
-                    type="button"
-                    onClick={handleAdd}
-                    disabled={addMutation.isPending || !newRow.waName || !newRow.catalogName}
-                    className="text-xs text-blue-600 hover:text-blue-800 disabled:opacity-50"
-                  >
-                    + {t('common.add')}
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
         </div>
       </div>
     </div>

--- a/src/web/pages/committee/EventCatalogPage.tsx
+++ b/src/web/pages/committee/EventCatalogPage.tsx
@@ -16,18 +16,34 @@ export default function EventCatalogPage() {
   const [name, setName] = useState('')
   const [discipline, setDiscipline] = useState<'Course' | 'Concours'>('Course')
   const [gender, setGender] = useState<'M' | 'F'>('M')
+  const [waName, setWaName] = useState('')
+  const [waRankingSlug, setWaRankingSlug] = useState('')
   const [editingId, setEditingId] = useState<string | null>(null)
 
-  const resetForm = () => { setName(''); setDiscipline('Course'); setGender('M'); setEditingId(null) }
+  const resetForm = () => {
+    setName('')
+    setDiscipline('Course')
+    setGender('M')
+    setWaName('')
+    setWaRankingSlug('')
+    setEditingId(null)
+  }
+
+  const buildPayload = () => ({
+    name: name.trim(),
+    discipline,
+    gender,
+    waName: waName.trim() || null,
+    waRankingSlug: waRankingSlug.trim() || null,
+  })
 
   const addMutation = useMutation({
-    mutationFn: (data: { name: string; discipline: string; gender: string }) =>
-      api.post('/api/v1/event-catalog', data),
+    mutationFn: (data: ReturnType<typeof buildPayload>) => api.post('/api/v1/event-catalog', data),
     onSuccess: () => { queryClient.invalidateQueries({ queryKey: ['event-catalog'] }); resetForm() },
   })
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, ...data }: { id: string; name: string; discipline: string; gender: string }) =>
+    mutationFn: ({ id, ...data }: { id: string } & ReturnType<typeof buildPayload>) =>
       api.patch(`/api/v1/event-catalog/${id}`, data),
     onSuccess: () => { queryClient.invalidateQueries({ queryKey: ['event-catalog'] }); resetForm() },
   })
@@ -42,15 +58,18 @@ export default function EventCatalogPage() {
     setName(item.name)
     setDiscipline(item.discipline as 'Course' | 'Concours')
     setGender(item.gender as 'M' | 'F')
+    setWaName(item.waName ?? '')
+    setWaRankingSlug(item.waRankingSlug ?? '')
   }
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (!name.trim()) return
+    const payload = buildPayload()
     if (editingId) {
-      updateMutation.mutate({ id: editingId, name: name.trim(), discipline, gender })
+      updateMutation.mutate({ id: editingId, ...payload })
     } else {
-      addMutation.mutate({ name: name.trim(), discipline, gender })
+      addMutation.mutate(payload)
     }
   }
 
@@ -63,55 +82,80 @@ export default function EventCatalogPage() {
   }
 
   return (
-    <div className="max-w-3xl mx-auto py-8 px-6">
+    <div className="max-w-5xl mx-auto py-8 px-6">
       <h1 className="text-lg font-bold mb-6">{t('admin.eventCatalog')}</h1>
 
-      <form onSubmit={handleSubmit} className="bg-white rounded-lg border p-4 mb-6 flex items-end gap-3">
-        <div className="flex-1">
-          <label className="block text-xs text-gray-500 mb-1">{t('admin.eventName')}</label>
-          <input
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-900"
-            placeholder="100m"
-          />
+      <form onSubmit={handleSubmit} className="bg-white rounded-lg border p-4 mb-6 space-y-3">
+        <div className="flex items-end gap-3">
+          <div className="flex-1">
+            <label className="block text-xs text-gray-500 mb-1">{t('admin.eventName')}</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-900"
+              placeholder="M100"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">{t('admin.discipline')}</label>
+            <select
+              value={discipline}
+              onChange={(e) => setDiscipline(e.target.value as 'Course' | 'Concours')}
+              className="px-2 py-1.5 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-900"
+            >
+              <option value="Course">Course</option>
+              <option value="Concours">Concours</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">{t('athlete.gender')}</label>
+            <select
+              value={gender}
+              onChange={(e) => setGender(e.target.value as 'M' | 'F')}
+              className="px-2 py-1.5 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-900"
+            >
+              <option value="M">{t('athlete.male')}</option>
+              <option value="F">{t('athlete.female')}</option>
+            </select>
+          </div>
         </div>
-        <div>
-          <label className="block text-xs text-gray-500 mb-1">{t('admin.discipline')}</label>
-          <select
-            value={discipline}
-            onChange={(e) => setDiscipline(e.target.value as 'Course' | 'Concours')}
-            className="px-2 py-1.5 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-900"
+        <div className="flex items-end gap-3">
+          <div className="flex-1">
+            <label className="block text-xs text-gray-500 mb-1">{t('admin.waName')}</label>
+            <input
+              type="text"
+              value={waName}
+              onChange={(e) => setWaName(e.target.value)}
+              className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-900"
+              placeholder="100 Metres"
+            />
+          </div>
+          <div className="flex-1">
+            <label className="block text-xs text-gray-500 mb-1">{t('admin.waRankingSlug')}</label>
+            <input
+              type="text"
+              value={waRankingSlug}
+              onChange={(e) => setWaRankingSlug(e.target.value)}
+              className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-900"
+              placeholder="100m"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={addMutation.isPending || updateMutation.isPending}
+            className="bg-gray-900 text-white text-sm font-medium px-4 py-1.5 rounded hover:bg-gray-800 disabled:opacity-50"
           >
-            <option value="Course">Course</option>
-            <option value="Concours">Concours</option>
-          </select>
-        </div>
-        <div>
-          <label className="block text-xs text-gray-500 mb-1">{t('athlete.gender')}</label>
-          <select
-            value={gender}
-            onChange={(e) => setGender(e.target.value as 'M' | 'F')}
-            className="px-2 py-1.5 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gray-900"
-          >
-            <option value="M">{t('athlete.male')}</option>
-            <option value="F">{t('athlete.female')}</option>
-          </select>
-        </div>
-        <button
-          type="submit"
-          disabled={addMutation.isPending || updateMutation.isPending}
-          className="bg-gray-900 text-white text-sm font-medium px-4 py-1.5 rounded hover:bg-gray-800 disabled:opacity-50"
-        >
-          {editingId ? t('common.save') : t('common.add')}
-        </button>
-        {editingId && (
-          <button type="button" onClick={resetForm}
-            className="text-sm text-gray-500 hover:text-gray-700 px-3 py-1.5">
-            {t('common.cancel')}
+            {editingId ? t('common.save') : t('common.add')}
           </button>
-        )}
+          {editingId && (
+            <button type="button" onClick={resetForm}
+              className="text-sm text-gray-500 hover:text-gray-700 px-3 py-1.5">
+              {t('common.cancel')}
+            </button>
+          )}
+        </div>
+        <p className="text-xs text-gray-400">{t('admin.waDisciplineMapHint')}</p>
       </form>
 
       <div className="bg-white rounded-lg border">
@@ -121,22 +165,26 @@ export default function EventCatalogPage() {
               <th className="px-3 py-2 text-left font-medium">{t('admin.eventName')}</th>
               <th className="px-3 py-2 text-left font-medium">{t('admin.discipline')}</th>
               <th className="px-3 py-2 text-left font-medium">{t('athlete.gender')}</th>
+              <th className="px-3 py-2 text-left font-medium">{t('admin.waName')}</th>
+              <th className="px-3 py-2 text-left font-medium">{t('admin.waRankingSlug')}</th>
               <th className="px-3 py-2 text-right font-medium">{t('common.actions')}</th>
             </tr>
           </thead>
           <tbody>
             {items.map((item) => (
               <tr key={item.id} className="border-b hover:bg-gray-50">
-                <td className="px-3 py-2">{item.name}</td>
+                <td className="px-3 py-2 font-mono text-xs">{item.name}</td>
                 <td className="px-3 py-2">{item.discipline}</td>
                 <td className="px-3 py-2">{item.gender}</td>
+                <td className="px-3 py-2 text-gray-600">{item.waName ?? <span className="text-gray-300">—</span>}</td>
+                <td className="px-3 py-2 text-gray-400 font-mono text-xs">{item.waRankingSlug ?? <span className="text-gray-300">—</span>}</td>
                 <td className="px-3 py-2 text-right space-x-2">
                   <button onClick={() => startEdit(item)}
                     className="text-xs text-blue-600 hover:text-blue-800">
                     {t('common.edit')}
                   </button>
                   <button
-                    onClick={() => deleteMutation.mutate(item.id)}
+                    onClick={() => { if (confirm(t('common.confirmDelete'))) deleteMutation.mutate(item.id) }}
                     className="text-xs text-red-600 hover:text-red-800"
                   >
                     {t('common.delete')}
@@ -146,7 +194,7 @@ export default function EventCatalogPage() {
             ))}
             {items.length === 0 && (
               <tr>
-                <td colSpan={4} className="px-3 py-4 text-center text-gray-400 text-xs">
+                <td colSpan={6} className="px-3 py-4 text-center text-gray-400 text-xs">
                   {t('common.none')}
                 </td>
               </tr>

--- a/tests/unit/wa-scraper.test.ts
+++ b/tests/unit/wa-scraper.test.ts
@@ -1,50 +1,44 @@
 import { describe, test, expect } from 'vitest'
-import { parseMark, DEFAULT_DISCIPLINE_MAPPINGS, scrapeWaProfile } from '../../src/api/services/wa-scraper'
+import { parseMark, scrapeWaProfile } from '../../src/api/services/wa-scraper'
 import type { DisciplineMapping } from '../../src/api/services/wa-scraper'
 
-const MAPPINGS: DisciplineMapping[] = DEFAULT_DISCIPLINE_MAPPINGS
+const TEST_MAPPINGS: DisciplineMapping[] = [
+  { waName: '100 Metres', waRankingSlug: '100m', catalogName: '100m', isField: false },
+  { waName: '200 Metres', waRankingSlug: '200m', catalogName: '200m', isField: false },
+  { waName: '400 Metres', waRankingSlug: '400m', catalogName: '400m', isField: false },
+  { waName: '800 Metres', waRankingSlug: '800m', catalogName: '800m', isField: false },
+  { waName: '1500 Metres', waRankingSlug: '1500m', catalogName: '1500m', isField: false },
+  { waName: '5000 Metres', waRankingSlug: '5000m', catalogName: '5000m', isField: false },
+  { waName: 'High Jump', waRankingSlug: 'high-jump', catalogName: 'High Jump', isField: true },
+  { waName: 'Long Jump', waRankingSlug: 'long-jump', catalogName: 'Long Jump', isField: true },
+  { waName: 'Pole Vault', waRankingSlug: 'pole-vault', catalogName: 'Pole Vault', isField: true },
+  { waName: 'Shot Put', waRankingSlug: 'shot-put', catalogName: 'Shot Put', isField: true },
+]
 
 describe('WA Scraper', () => {
   describe('parseMark', () => {
     test('parses simple track time', () => {
-      expect(parseMark('9.80', '100m')).toBe(9.80)
-      expect(parseMark('19.67', '200m')).toBe(19.67)
-      expect(parseMark('43.03', '400m')).toBe(43.03)
+      expect(parseMark('9.80', false)).toBe(9.80)
+      expect(parseMark('19.67', false)).toBe(19.67)
+      expect(parseMark('43.03', false)).toBe(43.03)
     })
 
     test('parses mm:ss.cc track time', () => {
-      expect(parseMark('3:26.00', '1500m')).toBe(206.00)
-      expect(parseMark('1:43.50', '800m')).toBe(103.50)
-      expect(parseMark('12:35.36', '5000m')).toBe(755.36)
+      expect(parseMark('3:26.00', false)).toBe(206.00)
+      expect(parseMark('1:43.50', false)).toBe(103.50)
+      expect(parseMark('12:35.36', false)).toBe(755.36)
     })
 
     test('parses field event marks as centimeters', () => {
-      expect(parseMark('2.35', 'High Jump')).toBe(235)
-      expect(parseMark('8.50', 'Long Jump')).toBe(850)
-      expect(parseMark('6.15', 'Pole Vault')).toBe(615)
-      expect(parseMark('22.63', 'Shot Put')).toBe(2263)
+      expect(parseMark('2.35', true)).toBe(235)
+      expect(parseMark('8.50', true)).toBe(850)
+      expect(parseMark('6.15', true)).toBe(615)
+      expect(parseMark('22.63', true)).toBe(2263)
     })
 
     test('returns null for empty/invalid marks', () => {
-      expect(parseMark('', '100m')).toBeNull()
-      expect(parseMark('abc', '100m')).toBeNull()
-    })
-  })
-
-  describe('DEFAULT_DISCIPLINE_MAPPINGS', () => {
-    test('covers all catalog events', () => {
-      const catalogNames = new Set(DEFAULT_DISCIPLINE_MAPPINGS.map(m => m.catalogName))
-      for (const name of ['100m', '200m', '400m', '400mH', '800m', '1500m', '5000m', 'High Jump', 'Long Jump', 'Pole Vault', 'Shot Put']) {
-        expect(catalogNames.has(name)).toBe(true)
-      }
-    })
-
-    test('all entries have both waName and waRankingSlug', () => {
-      for (const m of DEFAULT_DISCIPLINE_MAPPINGS) {
-        expect(m.waName).toBeTruthy()
-        expect(m.waRankingSlug).toBeTruthy()
-        expect(m.catalogName).toBeTruthy()
-      }
+      expect(parseMark('', false)).toBeNull()
+      expect(parseMark('abc', false)).toBeNull()
     })
   })
 
@@ -90,7 +84,7 @@ describe('WA Scraper', () => {
       globalThis.fetch = async () => new Response(mockHtml, { status: 200 })
 
       try {
-        const result = await scrapeWaProfile('https://worldathletics.org/athletes/test/test-runner-12345', MAPPINGS)
+        const result = await scrapeWaProfile('https://worldathletics.org/athletes/test/test-runner-12345', TEST_MAPPINGS)
 
         expect(result.athleteName).toBe('Test RUNNER')
         expect(result.performances).toHaveLength(3) // 100m, 200m, High Jump


### PR DESCRIPTION
Closes #78

Moves WA discipline mapping from the separate `wa_discipline_map` table into the `event_catalog` table as two optional columns (`wa_name`, `wa_ranking_slug`).

This design resolves the gender-specific catalog name problem natively: since each catalog entry is already gender-specific (M100, W100), each carries its own WA mapping, and the scraper filters by athlete gender when loading mappings.

Generated with [Claude Code](https://claude.ai/code)