### PR TITLE
fix: correct formatPerf for field events (Concours) below 10m

### DIFF
--- a/src/web/lib/ui-constants.ts
+++ b/src/web/lib/ui-constants.ts
@@ -21,9 +21,11 @@ export const inputCls =
 export const labelCls =
   'block text-xs font-medium text-gray-500 mb-1'
 
-export function formatPerf(value: number | null | undefined): string {
+export function formatPerf(value: number | null | undefined, discipline?: string): string {
   if (value == null) return '—'
-  // Distances/heights stored in cm (≥1000 means ≥10m) — format as m.cm
+  // Field events (Concours) are stored in centimeters — convert to meters
+  if (discipline === 'Concours') return (value / 100).toFixed(2)
+  // Fallback for legacy callers without discipline: assume cm if value ≥ 1000
   if (value >= 1000) return (value / 100).toFixed(2)
   // Times in seconds — format as ss.cc or m:ss.cc
   if (value < 60) return value.toFixed(2)

--- a/src/web/pages/collaborator/CandidatesPage.tsx
+++ b/src/web/pages/collaborator/CandidatesPage.tsx
@@ -91,12 +91,12 @@ function seasonBestColor(app: ApplicationRow, sb: number | null): string {
   return eligible ? 'text-green-600 font-semibold' : 'text-red-600'
 }
 
-function MinimaRow({ label, value }: { label: string; value: number | null | undefined }) {
+function MinimaRow({ label, value, discipline }: { label: string; value: number | null | undefined; discipline: string }) {
   return (
     <div className="flex items-center justify-between gap-4">
       <span className="text-xs text-gray-500">{label}</span>
       <span className="text-xs font-mono font-semibold text-gray-900">
-        {value != null ? formatPerf(value) : 'N/A'}
+        {value != null ? formatPerf(value, discipline) : 'N/A'}
       </span>
     </div>
   )
@@ -195,9 +195,9 @@ function EventInfoPanel({
             {t('selection.minima')}
           </p>
           <div className="space-y-1.5">
-            <MinimaRow label={t('selection.international')} value={event.intMinima} />
-            <MinimaRow label={t('selection.swiss')} value={event.swissMinima} />
-            <MinimaRow label={t('selection.eap')} value={event.eapMinima} />
+            <MinimaRow label={t('selection.international')} value={event.intMinima} discipline={event.discipline} />
+            <MinimaRow label={t('selection.swiss')} value={event.swissMinima} discipline={event.discipline} />
+            <MinimaRow label={t('selection.eap')} value={event.eapMinima} discipline={event.discipline} />
           </div>
         </div>
 
@@ -383,12 +383,12 @@ function CandidateRow({
 
       {/* Personal best */}
       <td className="px-3 py-2.5 font-mono text-xs text-gray-700">
-        {formatPerf(pb)}
+        {formatPerf(pb, app.event.catalog.discipline)}
       </td>
 
       {/* Season best */}
       <td className={`px-3 py-2.5 font-mono text-xs ${sbColor}`}>
-        {formatPerf(sb)}
+        {formatPerf(sb, app.event.catalog.discipline)}
       </td>
 
       {/* World ranking */}

--- a/src/web/pages/collaborator/athlete/BannerEventRow.tsx
+++ b/src/web/pages/collaborator/athlete/BannerEventRow.tsx
@@ -76,8 +76,9 @@ export function ScoringPopup({ app, athlete, edition, t, style }: {
 
 // ── ConfirmedAthletesPopup ──────────────────────────────────────────────────
 
-function ConfirmedAthletesPopup({ eventId, t }: {
+function ConfirmedAthletesPopup({ eventId, discipline, t }: {
   eventId: string
+  discipline: string
   t: (key: string) => string
 }) {
   const { data: confirmed = [], isLoading } = useQuery<ApplicationRow[]>({
@@ -108,7 +109,7 @@ function ConfirmedAthletesPopup({ eventId, t }: {
               <div key={a.id} className="flex justify-between text-gray-700">
                 <span>{a.athlete.lastName}, {a.athlete.firstName}</span>
                 <span className="font-mono text-gray-500">
-                  {formatPerf(a.waPerformance?.seasonBest ?? a.seasonBest ?? null)}
+                  {formatPerf(a.waPerformance?.seasonBest ?? a.seasonBest ?? null, discipline)}
                 </span>
               </div>
             ))}
@@ -144,12 +145,17 @@ export function BannerEventRow({ app, athlete, edition, isStaff, onParticipation
   isPendingParticipation: boolean
   t: (key: string) => string
 }) {
+  const isField = app.event.catalog.discipline === 'Concours'
   const [showEventPopup, setShowEventPopup] = useState(false)
   const [showScorePopup, setShowScorePopup] = useState(false)
   const [editingPerf, setEditingPerf] = useState(false)
   const [perfForm, setPerfForm] = useState({
-    personalBest: app.waPerformance?.personalBest != null ? String(app.waPerformance.personalBest) : '',
-    seasonBest: app.waPerformance?.seasonBest != null ? String(app.waPerformance.seasonBest) : '',
+    personalBest: app.waPerformance?.personalBest != null
+      ? String(isField ? app.waPerformance.personalBest / 100 : app.waPerformance.personalBest)
+      : '',
+    seasonBest: app.waPerformance?.seasonBest != null
+      ? String(isField ? app.waPerformance.seasonBest / 100 : app.waPerformance.seasonBest)
+      : '',
     worldRanking: app.waPerformance?.worldRanking != null ? String(app.waPerformance.worldRanking) : '',
   })
 
@@ -175,7 +181,7 @@ export function BannerEventRow({ app, athlete, edition, isStaff, onParticipation
         >
           {app.event.catalog.name}
         </button>
-        {showEventPopup && <ConfirmedAthletesPopup eventId={app.eventId} t={t} />}
+        {showEventPopup && <ConfirmedAthletesPopup eventId={app.eventId} discipline={app.event.catalog.discipline} t={t} />}
       </div>
 
       {/* PB / SB (colored) / Ranking */}
@@ -189,8 +195,8 @@ export function BannerEventRow({ app, athlete, edition, isStaff, onParticipation
             onChange={e => setPerfForm(p => ({ ...p, worldRanking: e.target.value }))} />
           <button onClick={() => {
             onWaPerfSave(athlete.id, app.eventId, {
-              ...(perfForm.personalBest ? { personalBest: parseFloat(perfForm.personalBest) } : {}),
-              ...(perfForm.seasonBest ? { seasonBest: parseFloat(perfForm.seasonBest) } : {}),
+              ...(perfForm.personalBest ? { personalBest: isField ? Math.round(parseFloat(perfForm.personalBest) * 100) : parseFloat(perfForm.personalBest) } : {}),
+              ...(perfForm.seasonBest ? { seasonBest: isField ? Math.round(parseFloat(perfForm.seasonBest) * 100) : parseFloat(perfForm.seasonBest) } : {}),
               ...(perfForm.worldRanking ? { worldRanking: parseInt(perfForm.worldRanking) } : {}),
             })
             setEditingPerf(false)
@@ -199,8 +205,8 @@ export function BannerEventRow({ app, athlete, edition, isStaff, onParticipation
         </div>
       ) : (
         <div className="flex items-center gap-3 text-xs text-gray-600 flex-1">
-          <span>PB: <span className="font-mono font-medium">{formatPerf(pb)}</span></span>
-          <span>SB: <span className={`font-mono font-medium ${sbColorClass(sb, app, athlete)}`}>{formatPerf(sb)}</span></span>
+          <span>PB: <span className="font-mono font-medium">{formatPerf(pb, app.event.catalog.discipline)}</span></span>
+          <span>SB: <span className={`font-mono font-medium ${sbColorClass(sb, app, athlete)}`}>{formatPerf(sb, app.event.catalog.discipline)}</span></span>
           <span>#{wr ?? '—'}</span>
 
           {/* Score with popup — staff only */}

--- a/src/web/pages/manager/PortalPage.tsx
+++ b/src/web/pages/manager/PortalPage.tsx
@@ -155,7 +155,7 @@ export default function ManagerPortalPage() {
                     </td>
                     <td className="px-3 py-2.5 text-xs">{ath.nationality}</td>
                     <td className="px-3 py-2.5 text-xs font-mono">
-                      {ath.applications.map(a => formatPerf(a.waPerformance?.seasonBest)).join(' / ') || '—'}
+                      {ath.applications.map(a => formatPerf(a.waPerformance?.seasonBest, a.event?.discipline)).join(' / ') || '—'}
                     </td>
                     <td className="px-3 py-2.5">
                       <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${STATUS_COLORS[ath.negotiationStatus]}`}>


### PR DESCRIPTION
Fixes #80

The `formatPerf` function used a threshold of ≥1000 to distinguish centimeter distances from seconds, which breaks for jumps < 10m (e.g. 7.18m → 718 cm, interpreted as 11:58.00).

Option B: keep centimeter storage, make `formatPerf` discipline-aware. Pass discipline to all call sites so Concours values are always divided by 100 regardless of magnitude.

Also fixes the Edit performance form: display and accept meters for Concours events, converting to/from centimeters on load/save.

Generated with [Claude Code](https://claude.ai/code)