### PR TITLE
feat: Améliorer le système d'emails

### DIFF
--- a/src/api/routes/athletes.ts
+++ b/src/api/routes/athletes.ts
@@ -5,7 +5,7 @@ import * as schema from '../db/schema'
 import { athleteRegistrationSchema, batchAthleteRegistrationSchema, athleteUpdateSchema, negotiationStatusChangeSchema, interactionSchema } from '@shared/validation'
 import { NEGOTIATION_TRANSITIONS, COMMITTEE_EXTRA_TRANSITIONS, ATHLETE_TRANSITIONS } from '@shared/constants'
 import { requireAuth } from '../middleware/auth'
-import { sendEmail, sendMagicLinkEmail, buildTransitionEmail } from '../services/email'
+import { sendEmail, sendApplicationEmail, buildTransitionEmail, buildManagerAthleteNotificationEmail, buildBatchNotificationEmail } from '../services/email'
 import type { EmailContent } from '../services/email'
 import { generateToken, magicLinkExpiresAt } from '../services/auth'
 import { recalculateAthleteEstimatedCost } from '../services/costEstimation'
@@ -142,7 +142,7 @@ athletes.post('/', zValidator('json', athleteRegistrationSchema), async (c) => {
     })
 
     const baseUrl = c.req.header('Origin') ?? 'http://localhost:5173'
-    emailPreview = await sendMagicLinkEmail(db, data.athleteEmail, token, baseUrl)
+    emailPreview = await sendApplicationEmail(db, data.athleteEmail, token, baseUrl, 'en', edition.name)
     magicLinkSent = true
   }
 
@@ -155,11 +155,29 @@ athletes.post('/', zValidator('json', athleteRegistrationSchema), async (c) => {
       .limit(1)
 
     if (managers.length > 0 && managers[0].email) {
-      await sendEmail({
+      const managerName = `${managers[0].firstName} ${managers[0].lastName}`
+      const notifEmail = buildManagerAthleteNotificationEmail({
+        managerName,
+        athleteFirstName: data.firstName,
+        athleteLastName: data.lastName,
+        meetingName: edition.name,
+        eventIds: data.eventIds,
+      })
+      const notifEmailId = await sendEmail({
         db,
         to: managers[0].email,
-        subject: `New athlete registered under your management: ${data.firstName} ${data.lastName}`,
-        body: `${data.firstName} ${data.lastName} has registered and listed you as their manager.\n\nEvents: ${data.eventIds.join(', ')}`,
+        subject: notifEmail.subject,
+        body: notifEmail.body,
+        htmlBody: notifEmail.htmlBody,
+        relatedAthleteId: athleteId,
+      })
+      await db.insert(schema.interaction).values({
+        athleteId,
+        type: 'manager_notification',
+        content: `Manager ${managerName} notified of new registration`,
+        authorName: `${data.firstName} ${data.lastName}`,
+        emailLogId: notifEmailId,
+        createdAt: new Date().toISOString(),
       })
     }
   }
@@ -250,15 +268,35 @@ athletes.post('/batch', requireAuth('manager'), zValidator('json', batchAthleteR
     results.push({ athleteId, applicationIds, firstName: data.firstName, lastName: data.lastName, eventIds: validEventIds })
   }
 
-  // Email stub to manager
-  await sendEmail({
+  // Email confirmation to manager
+  const managerName = `${user.firstName} ${user.lastName}`
+  const batchEmail = buildBatchNotificationEmail({
+    managerName,
+    meetingName: edition.name,
+    athletes: results.map(r => ({ firstName: r.firstName, lastName: r.lastName, eventIds: r.eventIds })),
+  })
+  const batchEmailId = await sendEmail({
     db,
     to: user.email ?? 'manager@unknown',
-    subject: `Batch registration complete — ${results.length} athletes`,
-    body: `You have registered ${results.length} athletes:\n${results.map(r => `- ${r.firstName} ${r.lastName} (${r.eventIds.join(', ')})`).join('\n')}`,
+    subject: batchEmail.subject,
+    body: batchEmail.body,
+    htmlBody: batchEmail.htmlBody,
   })
 
-  return c.json({ registered: results }, 201)
+  // Create interaction per athlete linking to the batch email
+  for (const r of results) {
+    await db.insert(schema.interaction).values({
+      athleteId: r.athleteId,
+      type: 'manager_notification',
+      content: `Batch registration confirmation sent to manager ${managerName}`,
+      authorName: managerName,
+      authorId: user.id,
+      emailLogId: batchEmailId,
+      createdAt: new Date().toISOString(),
+    })
+  }
+
+  return c.json({ registered: results, emailPreview: batchEmail }, 201)
 })
 
 // ── GET /athletes/:id — full athlete profile with applications, agreements, interactions ─
@@ -522,6 +560,7 @@ athletes.patch('/:id/negotiation-status', requireAuth('athlete', 'manager', 'col
         to: emailTo,
         subject: transitionEmail.subject,
         body: transitionEmail.body,
+        htmlBody: transitionEmail.htmlBody,
         relatedAthleteId: id,
       })
     }
@@ -534,6 +573,7 @@ athletes.patch('/:id/negotiation-status', requireAuth('athlete', 'manager', 'col
       to: edition.notificationEmail,
       subject: transitionEmail.subject,
       body: transitionEmail.body,
+      htmlBody: transitionEmail.htmlBody,
       relatedAthleteId: id,
     })
   }

--- a/src/api/routes/auth.ts
+++ b/src/api/routes/auth.ts
@@ -4,7 +4,7 @@ import { eq, or } from 'drizzle-orm'
 import * as schema from '../db/schema'
 import { loginSchema, magicLinkRequestSchema, magicLinkVerifySchema, identifySchema, loginWithPasswordSchema } from '@shared/validation'
 import { verifyPassword, generateToken, sessionExpiresAt, magicLinkExpiresAt } from '../services/auth'
-import { sendMagicLinkEmail } from '../services/email'
+import { sendLoginLinkEmail } from '../services/email'
 import { requireAuth } from '../middleware/auth'
 import type { Env } from '../index'
 
@@ -85,7 +85,9 @@ auth.post('/magic-link', zValidator('json', magicLinkRequestSchema), async (c) =
 
   const baseUrl = c.req.header('Origin') ?? 'http://localhost:5173'
   const lang = (user.preferredLang as 'en' | 'fr') ?? 'en'
-  await sendMagicLinkEmail(db, email, token, baseUrl, lang)
+  const editions = await db.select().from(schema.edition).limit(1)
+  const meetingName = editions[0]?.name ?? 'Atletica Geneve'
+  await sendLoginLinkEmail(db, email, token, baseUrl, lang, meetingName)
 
   return c.json({ message: 'If an account exists, a login link has been sent' })
 })
@@ -116,7 +118,7 @@ auth.post('/identify', zValidator('json', identifySchema), async (c) => {
   }
 
   // User is athlete/manager → send magic link
-  let emailPreview: { subject: string; body: string } | undefined
+  let emailPreview: { subject: string; body: string; htmlBody?: string } | undefined
   if (user.email) {
     const token = generateToken()
     await db.insert(schema.magicLink).values({
@@ -126,8 +128,10 @@ auth.post('/identify', zValidator('json', identifySchema), async (c) => {
     })
     const baseUrl = c.req.header('Origin') ?? 'http://localhost:5173'
     const lang = (user.preferredLang as 'en' | 'fr') ?? 'en'
-    const result = await sendMagicLinkEmail(db, user.email, token, baseUrl, lang)
-    emailPreview = { subject: result.subject, body: result.body }
+    const editions = await db.select().from(schema.edition).limit(1)
+    const meetingName = editions[0]?.name ?? 'Atletica Geneve'
+    const result = await sendLoginLinkEmail(db, user.email, token, baseUrl, lang, meetingName)
+    emailPreview = { subject: result.subject, body: result.body, htmlBody: result.htmlBody }
   }
 
   return c.json({ method: 'magic_link', message: 'If this email is registered, a login link has been sent.', emailPreview })

--- a/src/api/routes/managers.ts
+++ b/src/api/routes/managers.ts
@@ -4,7 +4,7 @@ import { eq } from 'drizzle-orm'
 import * as schema from '../db/schema'
 import { managerRegistrationSchema } from '@shared/validation'
 import { generateToken, sessionExpiresAt, magicLinkExpiresAt } from '../services/auth'
-import { sendMagicLinkEmail } from '../services/email'
+import { sendLoginLinkEmail } from '../services/email'
 import type { Env } from '../index'
 
 const managers = new Hono<Env>()
@@ -27,7 +27,10 @@ managers.post('/register', zValidator('json', managerRegistrationSchema), async 
       expiresAt: magicLinkExpiresAt(),
     })
     const baseUrl = c.req.header('Origin') ?? 'http://localhost:5173'
-    await sendMagicLinkEmail(db, data.email, token, baseUrl, (user.preferredLang as 'en' | 'fr') ?? 'en')
+    const lang = (user.preferredLang as 'en' | 'fr') ?? 'en'
+    const editions = await db.select().from(schema.edition).limit(1)
+    const meetingName = editions[0]?.name ?? 'Atletica Geneve'
+    await sendLoginLinkEmail(db, data.email, token, baseUrl, lang, meetingName)
     return c.json({ message: 'Account exists — login link sent' })
   }
 

--- a/src/api/routes/portal.ts
+++ b/src/api/routes/portal.ts
@@ -5,7 +5,7 @@ import * as schema from '../db/schema'
 import { portalRespondSchema } from '@shared/validation'
 import { requireAuth } from '../middleware/auth'
 import { calculateTotalCost } from '../lib/helpers'
-import { sendEmail } from '../services/email'
+import { sendEmail, buildPortalResponseEmail } from '../services/email'
 import type { Env } from '../index'
 import type { NegotiationStatus } from '@shared/types'
 
@@ -310,11 +310,20 @@ portal.post('/athlete/:athleteId/respond', requireAuth('athlete', 'manager'), zV
   const editions = await db.select().from(schema.edition).limit(1)
   const notificationEmail = editions[0]?.notificationEmail
   if (notificationEmail) {
+    const emailContent = buildPortalResponseEmail({
+      athleteFirstName: ath.firstName,
+      athleteLastName: ath.lastName,
+      gender: ath.gender ?? '',
+      action,
+      newStatus,
+      meetingName: editions[0]?.name ?? 'Atletica Geneve',
+    })
     await sendEmail({
       db,
       to: notificationEmail,
-      subject: `Application update — ${ath.firstName} ${ath.lastName}`,
-      body: `${ath.firstName} ${ath.lastName} has ${action}ed the offer.\nNew status: ${newStatus}`,
+      subject: emailContent.subject,
+      body: emailContent.body,
+      htmlBody: emailContent.htmlBody,
       relatedAthleteId: athleteId,
     })
   }

--- a/src/api/services/email.ts
+++ b/src/api/services/email.ts
@@ -18,7 +18,6 @@ interface EmailParams {
 }
 
 export async function sendEmail({ db, to, subject, body, htmlBody, lang = 'en', relatedAthleteId }: EmailParams): Promise<string> {
-  // Persist to email_log and return the ID
   const emailId = crypto.randomUUID()
   await db.insert(schema.emailLog).values({
     id: emailId,
@@ -47,24 +46,81 @@ export interface EmailContent {
   htmlBody: string
 }
 
-export async function sendMagicLinkEmail(db: Db, email: string, token: string, baseUrl: string, lang: 'en' | 'fr' = 'en'): Promise<EmailContent> {
+function linkButton(link: string, label: string): string {
+  return `<p style="margin:20px 0;text-align:center"><a href="${link}" style="display:inline-block;padding:12px 28px;background:#1a1a1a;color:#ffffff;text-decoration:none;border-radius:6px;font-weight:600;font-size:14px">${label}</a></p>`
+}
+
+function textToHtml(text: string): string {
+  const escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  const paragraphs = escaped.split(/\n{2,}/).map(block => `<p>${block.replace(/\n/g, '<br/>')}</p>`).join('\n')
+  return `<div style="font-family:sans-serif;font-size:14px;line-height:1.6;color:#333">${paragraphs}</div>`
+}
+
+// ── Case (a): athlete self-registration ──────────────────────────────────────
+export async function sendApplicationEmail(
+  db: Db, email: string, token: string, baseUrl: string, lang: 'en' | 'fr' = 'en', meetingName = 'Atletica Geneve'
+): Promise<EmailContent> {
   const link = `${baseUrl}/auth/verify?token=${token}`
-  const subject = lang === 'fr' ? 'Votre candidature — Atletica Genève' : 'Your application — Atletica Geneve'
+  const subject = lang === 'fr'
+    ? `${meetingName} — Votre candidature`
+    : `${meetingName} — Your Application`
+
   const body = lang === 'fr'
-    ? `Chère athlète, cher athlète,\n\nNous avons bien reçu votre demande de participation à Atletica Genève et nous vous en remercions chaleureusement.\n\nVotre candidature sera examinée avec la plus grande attention par l'équipe d'Atletica Genève. Nous étudions chaque dossier avec soin afin d'offrir le meilleur meeting possible.\n\nPour suivre l'avancement de votre candidature, vous pouvez accéder à votre espace personnel en cliquant sur le lien ci-dessous :\n\n${link}\n\nCe lien est à usage unique et expire dans 30 minutes. Vous continuerez naturellement à être informé(e) par email à chaque étape importante de votre dossier.\n\nNous vous souhaitons bonne chance et espérons avoir le plaisir de vous accueillir à Genève.\n\nBien cordialement,\nL'équipe Atletica Genève`
-    : `Dear athlete,\n\nWe have received your request to participate in Atletica Geneve and we sincerely thank you for your interest.\n\nYour application will be carefully reviewed by the Atletica Geneve team. We take great care in examining every submission to ensure the best possible meeting.\n\nTo follow the progress of your application, you can access your personal portal by clicking the link below:\n\n${link}\n\nThis link is single-use and expires in 30 minutes. You will of course continue to be informed by email at every important stage of your application.\n\nWe wish you the best of luck and hope to have the pleasure of welcoming you to Geneva.\n\nWarm regards,\nThe Atletica Geneve Team`
+    ? `Chère athlète, cher athlète,\n\nNous avons bien reçu votre demande de participation à ${meetingName} et nous vous en remercions chaleureusement.\n\nVotre candidature sera examinée avec la plus grande attention par l'équipe d'Atletica Genève. Nous étudions chaque dossier avec soin afin d'offrir le meilleur meeting possible.\n\nPour suivre l'avancement de votre candidature, vous pouvez accéder à votre espace personnel en cliquant sur le lien ci-dessous :\n\n${link}\n\nCe lien est à usage unique et expire dans 30 minutes. Vous continuerez naturellement à être informé(e) par email à chaque étape importante de votre dossier.\n\nNous vous souhaitons bonne chance et espérons avoir le plaisir de vous accueillir à Genève.\n\nBien cordialement,\nL'équipe Atletica Genève`
+    : `Dear athlete,\n\nWe have received your request to participate in ${meetingName} and we sincerely thank you for your interest.\n\nYour application will be carefully reviewed by the Atletica Geneve team. We take great care in examining every submission to ensure the best possible meeting.\n\nTo follow the progress of your application, you can access your personal portal by clicking the link below:\n\n${link}\n\nThis link is single-use and expires in 30 minutes. You will of course continue to be informed by email at every important stage of your application.\n\nWe wish you the best of luck and hope to have the pleasure of welcoming you to Geneva.\n\nWarm regards,\nThe Atletica Geneve Team`
 
   const htmlBody = lang === 'fr'
-    ? `<p>Chère athlète, cher athlète,</p><p>Nous avons bien reçu votre demande de participation à <strong>Atletica Genève</strong> et nous vous en remercions chaleureusement.</p><p>Votre candidature sera examinée avec la plus grande attention par l'équipe d'Atletica Genève. Nous étudions chaque dossier avec soin afin d'offrir le meilleur meeting possible.</p><p>Pour suivre l'avancement de votre candidature, vous pouvez accéder à votre espace personnel en cliquant sur le lien ci-dessous :</p><p><a href="${link}">${link}</a></p><p><em>Ce lien est à usage unique et expire dans 30 minutes. Vous continuerez naturellement à être informé(e) par email à chaque étape importante de votre dossier.</em></p><p>Nous vous souhaitons bonne chance et espérons avoir le plaisir de vous accueillir à Genève.</p><p>Bien cordialement,<br/>L'équipe Atletica Genève</p>`
-    : `<p>Dear athlete,</p><p>We have received your request to participate in <strong>Atletica Geneve</strong> and we sincerely thank you for your interest.</p><p>Your application will be carefully reviewed by the Atletica Geneve team. We take great care in examining every submission to ensure the best possible meeting.</p><p>To follow the progress of your application, you can access your personal portal by clicking the link below:</p><p><a href="${link}">${link}</a></p><p><em>This link is single-use and expires in 30 minutes. You will of course continue to be informed by email at every important stage of your application.</em></p><p>We wish you the best of luck and hope to have the pleasure of welcoming you to Geneva.</p><p>Warm regards,<br/>The Atletica Geneve Team</p>`
+    ? `<div style="font-family:sans-serif;font-size:14px;line-height:1.6;color:#333"><p>Chère athlète, cher athlète,</p><p>Nous avons bien reçu votre demande de participation à <strong>${meetingName}</strong> et nous vous en remercions chaleureusement.</p><p>Votre candidature sera examinée avec la plus grande attention par l'équipe d'Atletica Genève. Nous étudions chaque dossier avec soin afin d'offrir le meilleur meeting possible.</p><p>Pour suivre l'avancement de votre candidature, accédez à votre espace personnel :</p>${linkButton(link, 'Accéder à mon espace')}<p style="font-size:12px;color:#666"><em>Ce lien est à usage unique et expire dans 30 minutes.</em></p><p>Nous vous souhaitons bonne chance et espérons avoir le plaisir de vous accueillir à Genève.</p><p>Bien cordialement,<br/>L'équipe Atletica Genève</p></div>`
+    : `<div style="font-family:sans-serif;font-size:14px;line-height:1.6;color:#333"><p>Dear athlete,</p><p>We have received your request to participate in <strong>${meetingName}</strong> and we sincerely thank you for your interest.</p><p>Your application will be carefully reviewed by the Atletica Geneve team. We take great care in examining every submission to ensure the best possible meeting.</p><p>To follow the progress of your application, access your personal portal:</p>${linkButton(link, 'Access my portal')}<p style="font-size:12px;color:#666"><em>This link is single-use and expires in 30 minutes.</em></p><p>We wish you the best of luck and hope to have the pleasure of welcoming you to Geneva.</p><p>Warm regards,<br/>The Atletica Geneve Team</p></div>`
 
   await sendEmail({ db, to: email, subject, body, htmlBody, lang })
+  return { subject, body, htmlBody }
+}
+
+// ── Cases (b)(c): existing user login link ────────────────────────────────────
+export async function sendLoginLinkEmail(
+  db: Db, email: string, token: string, baseUrl: string, lang: 'en' | 'fr' = 'en', meetingName = 'Atletica Geneve'
+): Promise<EmailContent> {
+  const link = `${baseUrl}/auth/verify?token=${token}`
+  const subject = lang === 'fr'
+    ? `${meetingName} — Votre lien de connexion`
+    : `${meetingName} — Your login link`
+
+  const body = lang === 'fr'
+    ? `Bonjour,\n\nVoici votre lien de connexion pour accéder à votre espace ${meetingName} :\n\n${link}\n\nCe lien est à usage unique et expire dans 30 minutes.\n\nSi vous n'avez pas demandé ce lien, vous pouvez ignorer cet email.\n\nBien cordialement,\nL'équipe Atletica Genève`
+    : `Hello,\n\nHere is your login link to access your ${meetingName} portal:\n\n${link}\n\nThis link is single-use and expires in 30 minutes.\n\nIf you did not request this link, you may safely ignore this email.\n\nWarm regards,\nThe Atletica Geneve Team`
+
+  const htmlBody = lang === 'fr'
+    ? `<div style="font-family:sans-serif;font-size:14px;line-height:1.6;color:#333"><p>Bonjour,</p><p>Voici votre lien de connexion pour accéder à votre espace <strong>${meetingName}</strong> :</p>${linkButton(link, 'Se connecter')}<p style="font-size:12px;color:#666"><em>Ce lien est à usage unique et expire dans 30 minutes. Si vous n'avez pas demandé ce lien, vous pouvez ignorer cet email.</em></p><p>Bien cordialement,<br/>L'équipe Atletica Genève</p></div>`
+    : `<div style="font-family:sans-serif;font-size:14px;line-height:1.6;color:#333"><p>Hello,</p><p>Here is your login link to access your <strong>${meetingName}</strong> portal:</p>${linkButton(link, 'Log in')}<p style="font-size:12px;color:#666"><em>This link is single-use and expires in 30 minutes. If you did not request this link, you may safely ignore this email.</em></p><p>Warm regards,<br/>The Atletica Geneve Team</p></div>`
+
+  await sendEmail({ db, to: email, subject, body, htmlBody, lang })
+  return { subject, body, htmlBody }
+}
+
+// ── Manager notification: new athlete registered under management ─────────────
+export function buildManagerAthleteNotificationEmail(params: {
+  managerName: string
+  athleteFirstName: string
+  athleteLastName: string
+  meetingName: string
+  eventIds: string[]
+}): EmailContent {
+  const { managerName, athleteFirstName, athleteLastName, meetingName, eventIds } = params
+  const athleteName = `${athleteFirstName} ${athleteLastName}`
+  const subject = `${meetingName} — New athlete registered under your management: ${athleteName}`
+
+  const body = `Dear ${managerName},\n\nA new athlete has registered for ${meetingName} and listed you as their manager.\n\nAthlete: ${athleteName}\nEvents: ${eventIds.join(', ')}\n\nYou can follow the progress of ${athleteName}'s application in your manager portal.\n\nKind regards,\nThe Atletica Geneve Team`
+
+  const htmlBody = `<div style="font-family:sans-serif;font-size:14px;line-height:1.6;color:#333"><p>Dear ${managerName},</p><p>A new athlete has registered for <strong>${meetingName}</strong> and listed you as their manager.</p><table style="border-collapse:collapse;margin:12px 0"><tr><td style="padding:4px 8px;font-weight:600">Athlete:</td><td style="padding:4px 8px">${athleteName}</td></tr><tr><td style="padding:4px 8px;font-weight:600">Events:</td><td style="padding:4px 8px">${eventIds.join(', ')}</td></tr></table><p>You can follow the progress of ${athleteName}'s application in your manager portal.</p><p>Kind regards,<br/>The Atletica Geneve Team</p></div>`
+
   return { subject, body, htmlBody }
 }
 
 export interface TransitionEmail {
   subject: string
   body: string
+  htmlBody: string
 }
 
 export function buildTransitionEmail(params: {
@@ -81,85 +137,148 @@ export function buildTransitionEmail(params: {
   const { from, to, athleteName, meetingName, senderName, recipientName, organizationName, agreementTerms, counterOfferText } = params
   const key = `${from}__${to}`
 
+  const make = (subject: string, body: string): TransitionEmail => ({
+    subject,
+    body,
+    htmlBody: textToHtml(body),
+  })
+
   switch (key) {
     case 'to_review__agreement_sent': {
       const termsSection = agreementTerms
         ? `\n\nHere are the terms of our offer:\n\n${agreementTerms}`
         : ''
-      return {
-        subject: `${meetingName} — Participation Agreement`,
-        body: `Dear ${recipientName},\n\nWe are pleased to inform you that we have reviewed ${athleteName}'s application for ${meetingName} and are ready to move forward with a participation offer.${termsSection}\n\nPlease let us know your decision at your earliest convenience. Should you have any questions or wish to discuss any aspect of the offer, please do not hesitate to reach out.\n\nKind regards,\n${senderName} — ${organizationName}`,
-      }
+      return make(
+        `${meetingName} — Participation Agreement`,
+        `Dear ${recipientName},\n\nWe are pleased to inform you that we have reviewed ${athleteName}'s application for ${meetingName} and are ready to move forward with a participation offer.${termsSection}\n\nPlease let us know your decision at your earliest convenience. Should you have any questions or wish to discuss any aspect of the offer, please do not hesitate to reach out.\n\nKind regards,\n${senderName} — ${organizationName}`,
+      )
     }
     case 'to_review__rejected':
-      return {
-        subject: `${meetingName} — Application Update`,
-        body: `Dear ${recipientName},\n\nThank you for ${athleteName}'s interest in participating in ${meetingName}.\n\nAfter careful review, we regret to inform you that we are unable to offer a place at this edition of the meeting.\n\nWe sincerely appreciate your trust and hope to have the opportunity to welcome ${athleteName} at a future event.\n\nKind regards,\n${senderName} — ${organizationName}`,
-      }
+      return make(
+        `${meetingName} — Application Update`,
+        `Dear ${recipientName},\n\nThank you for ${athleteName}'s interest in participating in ${meetingName}.\n\nAfter careful review, we regret to inform you that we are unable to offer a place at this edition of the meeting.\n\nWe sincerely appreciate your trust and hope to have the opportunity to welcome ${athleteName} at a future event.\n\nKind regards,\n${senderName} — ${organizationName}`,
+      )
     case 'to_review__withdrawn':
-      return {
-        subject: `${meetingName} — Withdrawal of Application`,
-        body: `Dear ${recipientName},\n\nI am writing to inform you that ${athleteName} is withdrawing their application for ${meetingName}.\n\nWe are sorry for any inconvenience this may cause and thank you for your understanding. We hope to have the opportunity to work together at a future event.\n\nKind regards,\n${senderName}`,
-      }
+      return make(
+        `${meetingName} — Withdrawal of Application`,
+        `Dear ${recipientName},\n\nI am writing to inform you that ${athleteName} is withdrawing their application for ${meetingName}.\n\nWe are sorry for any inconvenience this may cause and thank you for your understanding. We hope to have the opportunity to work together at a future event.\n\nKind regards,\n${senderName}`,
+      )
     case 'agreement_sent__confirmed':
-      return {
-        subject: `${meetingName} — Agreement Accepted`,
-        body: `Dear ${recipientName},\n\nWe are delighted to confirm ${athleteName}'s participation in ${meetingName} on the terms set out in the agreement.\n\nWe look forward to the event and thank you for the opportunity.\n\nKind regards,\n${senderName}`,
-      }
+      return make(
+        `${meetingName} — Agreement Accepted`,
+        `Dear ${recipientName},\n\nWe are delighted to confirm ${athleteName}'s participation in ${meetingName} on the terms set out in the agreement.\n\nWe look forward to the event and thank you for the opportunity.\n\nKind regards,\n${senderName}`,
+      )
     case 'agreement_sent__counter_offer_sent': {
       const counterSection = counterOfferText
         ? `\n\nHere is our counter-proposal:\n\n${counterOfferText}`
         : '\n\nPlease find our counter-offer attached.'
-      return {
-        subject: `${meetingName} — Counter-offer`,
-        body: `Dear ${recipientName},\n\nThank you for sending the participation agreement for ${athleteName} at ${meetingName}.\n\nHaving reviewed the proposed terms, we would like to suggest some adjustments.${counterSection}\n\nWe remain open to discussion and look forward to reaching a mutually satisfactory agreement.\n\nKind regards,\n${senderName}`,
-      }
+      return make(
+        `${meetingName} — Counter-offer`,
+        `Dear ${recipientName},\n\nThank you for sending the participation agreement for ${athleteName} at ${meetingName}.\n\nHaving reviewed the proposed terms, we would like to suggest some adjustments.${counterSection}\n\nWe remain open to discussion and look forward to reaching a mutually satisfactory agreement.\n\nKind regards,\n${senderName}`,
+      )
     }
     case 'agreement_sent__withdrawn':
-      return {
-        subject: `${meetingName} — Withdrawal`,
-        body: `Dear ${recipientName},\n\nAfter careful consideration, we regret to inform you that ${athleteName} must withdraw from ${meetingName}.\n\nWe are sorry for any inconvenience this may cause and sincerely thank you for the opportunity that was extended. We hope to be able to collaborate at a future event.\n\nKind regards,\n${senderName}`,
-      }
+      return make(
+        `${meetingName} — Withdrawal`,
+        `Dear ${recipientName},\n\nAfter careful consideration, we regret to inform you that ${athleteName} must withdraw from ${meetingName}.\n\nWe are sorry for any inconvenience this may cause and sincerely thank you for the opportunity that was extended. We hope to be able to collaborate at a future event.\n\nKind regards,\n${senderName}`,
+      )
     case 'counter_offer_sent__agreement_sent': {
       const termsSection = agreementTerms
         ? `\n\nHere are the revised terms:\n\n${agreementTerms}`
         : ''
-      return {
-        subject: `${meetingName} — Updated Participation Agreement`,
-        body: `Dear ${recipientName},\n\nThank you for your counter-offer regarding ${athleteName}'s participation in ${meetingName}. We have taken your points into consideration and are pleased to send you an updated participation offer.${termsSection}\n\nWe hope this revised proposal meets your expectations. Please do not hesitate to contact us if you have any further questions.\n\nKind regards,\n${senderName} — ${organizationName}`,
-      }
+      return make(
+        `${meetingName} — Updated Participation Agreement`,
+        `Dear ${recipientName},\n\nThank you for your counter-offer regarding ${athleteName}'s participation in ${meetingName}. We have taken your points into consideration and are pleased to send you an updated participation offer.${termsSection}\n\nWe hope this revised proposal meets your expectations. Please do not hesitate to contact us if you have any further questions.\n\nKind regards,\n${senderName} — ${organizationName}`,
+      )
     }
     case 'counter_offer_sent__rejected':
-      return {
-        subject: `${meetingName} — End of Negotiations`,
-        body: `Dear ${recipientName},\n\nThank you for your counter-offer regarding ${athleteName}'s participation in ${meetingName}.\n\nAfter careful consideration, we regret to inform you that we are unable to reach an agreement for this edition of the meeting.\n\nWe sincerely value your interest and hope to have the opportunity to work together in the future.\n\nKind regards,\n${senderName} — ${organizationName}`,
-      }
+      return make(
+        `${meetingName} — End of Negotiations`,
+        `Dear ${recipientName},\n\nThank you for your counter-offer regarding ${athleteName}'s participation in ${meetingName}.\n\nAfter careful consideration, we regret to inform you that we are unable to reach an agreement for this edition of the meeting.\n\nWe sincerely value your interest and hope to have the opportunity to work together in the future.\n\nKind regards,\n${senderName} — ${organizationName}`,
+      )
     case 'counter_offer_sent__withdrawn':
-      return {
-        subject: `${meetingName} — Withdrawal`,
-        body: `Dear ${recipientName},\n\nFurther to our counter-offer, we have decided to withdraw ${athleteName}'s candidacy for ${meetingName}.\n\nWe thank you for the time and effort devoted to the negotiation and apologize for any inconvenience caused. We hope to have the pleasure of working together at a future event.\n\nKind regards,\n${senderName}`,
-      }
+      return make(
+        `${meetingName} — Withdrawal`,
+        `Dear ${recipientName},\n\nFurther to our counter-offer, we have decided to withdraw ${athleteName}'s candidacy for ${meetingName}.\n\nWe thank you for the time and effort devoted to the negotiation and apologize for any inconvenience caused. We hope to have the pleasure of working together at a future event.\n\nKind regards,\n${senderName}`,
+      )
     case 'confirmed__withdrawn':
-      return {
-        subject: `${meetingName} — Withdrawal of Confirmed Participation`,
-        body: `Dear ${recipientName},\n\nWe regret to inform you that ${athleteName} is unfortunately forced to withdraw from ${meetingName}, despite having previously confirmed their participation.\n\nWe sincerely apologize for the disruption this may cause to your event organization and thank you for your understanding. Please do not hesitate to contact us if you need any further information.\n\nKind regards,\n${senderName}`,
-      }
+      return make(
+        `${meetingName} — Withdrawal of Confirmed Participation`,
+        `Dear ${recipientName},\n\nWe regret to inform you that ${athleteName} is unfortunately forced to withdraw from ${meetingName}, despite having previously confirmed their participation.\n\nWe sincerely apologize for the disruption this may cause to your event organization and thank you for your understanding. Please do not hesitate to contact us if you need any further information.\n\nKind regards,\n${senderName}`,
+      )
     case 'confirmed__rejected':
-      return {
-        subject: `${meetingName} — Update Regarding ${athleteName}'s Participation`,
-        body: `Dear ${recipientName},\n\nWe regret to inform you that, due to exceptional circumstances, ${athleteName}'s confirmed participation in ${meetingName} has had to be cancelled.\n\nWe are truly sorry for the inconvenience this causes and want to assure you that this decision was not taken lightly. We remain available to discuss this matter and hope to have the opportunity to welcome ${athleteName} at a future event.\n\nKind regards,\n${senderName} — ${organizationName}`,
-      }
+      return make(
+        `${meetingName} — Update Regarding ${athleteName}'s Participation`,
+        `Dear ${recipientName},\n\nWe regret to inform you that, due to exceptional circumstances, ${athleteName}'s confirmed participation in ${meetingName} has had to be cancelled.\n\nWe are truly sorry for the inconvenience this causes and want to assure you that this decision was not taken lightly. We remain available to discuss this matter and hope to have the opportunity to welcome ${athleteName} at a future event.\n\nKind regards,\n${senderName} — ${organizationName}`,
+      )
     case 'rejected__to_review':
-      return {
-        subject: `${meetingName} — Application Reopened`,
-        body: `Dear ${recipientName},\n\nFollowing our previous communication, we are pleased to inform you that ${athleteName}'s application for ${meetingName} has been reopened.\n\nWe would like to invite you to resume discussions with us. Please feel free to contact us at your convenience.\n\nKind regards,\n${senderName} — ${organizationName}`,
-      }
+      return make(
+        `${meetingName} — Application Reopened`,
+        `Dear ${recipientName},\n\nFollowing our previous communication, we are pleased to inform you that ${athleteName}'s application for ${meetingName} has been reopened.\n\nWe would like to invite you to resume discussions with us. Please feel free to contact us at your convenience.\n\nKind regards,\n${senderName} — ${organizationName}`,
+      )
     case 'withdrawn__to_review':
-      return {
-        subject: `${meetingName} — Invitation to Reconsider`,
-        body: `Dear ${recipientName},\n\nFollowing ${athleteName}'s withdrawal from ${meetingName}, we would like to reach out and explore whether there might be an opportunity to resume the process.\n\nIf circumstances have changed and you would be open to reconsidering, we would be very pleased to discuss this with you. Please feel free to contact us.\n\nKind regards,\n${senderName} — ${organizationName}`,
-      }
+      return make(
+        `${meetingName} — Invitation to Reconsider`,
+        `Dear ${recipientName},\n\nFollowing ${athleteName}'s withdrawal from ${meetingName}, we would like to reach out and explore whether there might be an opportunity to resume the process.\n\nIf circumstances have changed and you would be open to reconsidering, we would be very pleased to discuss this with you. Please feel free to contact us.\n\nKind regards,\n${senderName} — ${organizationName}`,
+      )
     default:
       return null
   }
+}
+
+// ── Batch registration confirmation (manager) ─────────────────────────────────
+export function buildBatchNotificationEmail(params: {
+  managerName: string
+  meetingName: string
+  athletes: Array<{ firstName: string; lastName: string; eventIds: string[] }>
+}): EmailContent {
+  const { managerName, meetingName, athletes } = params
+  const count = athletes.length
+  const plural = count > 1
+
+  const athleteList = athletes
+    .map(a => `  - ${a.firstName} ${a.lastName} (${a.eventIds.join(', ')})`)
+    .join('\n')
+
+  const subject = `${meetingName} — Batch registration complete — ${count} athlete${plural ? 's' : ''}`
+
+  const body = `Dear ${managerName},\n\nWe are pleased to confirm that your batch registration for ${meetingName} has been processed successfully.\n\nThe following ${count} athlete${plural ? 's have' : ' has'} been registered:\n\n${athleteList}\n\nEach application has been submitted and is now under review. You will be kept informed of any updates regarding the status of each athlete's participation.\n\nShould you have any questions or need to make changes, please do not hesitate to contact us.\n\nKind regards,\nThe Atletica Geneve Team`
+
+  const htmlRows = athletes
+    .map(a => `<tr><td style="padding:4px 8px">${a.firstName} ${a.lastName}</td><td style="padding:4px 8px;color:#666">${a.eventIds.join(', ')}</td></tr>`)
+    .join('\n')
+
+  const htmlBody = `<div style="font-family:sans-serif;font-size:14px;line-height:1.6;color:#333"><p>Dear ${managerName},</p><p>We are pleased to confirm that your batch registration for <strong>${meetingName}</strong> has been processed successfully.</p><p>The following ${count} athlete${plural ? 's have' : ' has'} been registered:</p><table style="border-collapse:collapse;width:100%;margin:12px 0"><thead><tr style="background:#f5f5f5"><th style="padding:6px 8px;text-align:left;border-bottom:1px solid #ddd">Athlete</th><th style="padding:6px 8px;text-align:left;border-bottom:1px solid #ddd">Events</th></tr></thead><tbody>${htmlRows}</tbody></table><p>Each application has been submitted and is now under review. You will be kept informed of any updates regarding the status of each athlete's participation.</p><p>Should you have any questions or need to make changes, please do not hesitate to contact us.</p><p>Kind regards,<br/>The Atletica Geneve Team</p></div>`
+
+  return { subject, body, htmlBody }
+}
+
+// ── Portal response notification (to organisation committee) ──────────────────
+export function buildPortalResponseEmail(params: {
+  athleteFirstName: string
+  athleteLastName: string
+  gender: string
+  action: string
+  newStatus: string
+  meetingName: string
+}): EmailContent {
+  const { athleteFirstName, athleteLastName, gender, action, newStatus, meetingName } = params
+  const athleteName = `${athleteFirstName} ${athleteLastName}`
+  const pronoun = gender === 'F' ? 'her' : 'his'
+
+  const actionDescriptions: Record<string, string> = {
+    accept: 'accepted the participation offer',
+    reject: 'rejected the participation offer',
+    withdraw: 'withdrawn from the meeting',
+    counter_offer: 'submitted a counter-offer',
+  }
+  const actionDesc = actionDescriptions[action] ?? `updated their application (${action})`
+
+  const subject = `Application update — ${athleteName}`
+
+  const body = `Dear ATLETICAGENEVE organisation committee,\n\n${athleteName} has ${actionDesc} for ${meetingName}.\n\n${athleteName} has updated ${pronoun} application status, which is now: ${newStatus}.\n\nPlease log in to the management platform to review this update and take any necessary action.\n\nThis is an automated notification from the Atletica Geneve registration system.`
+
+  const htmlBody = `<div style="font-family:sans-serif;font-size:14px;line-height:1.6;color:#333"><p>Dear ATLETICAGENEVE organisation committee,</p><p><strong>${athleteName}</strong> has ${actionDesc} for <strong>${meetingName}</strong>.</p><p>${athleteName} has updated ${pronoun} application status, which is now: <strong>${newStatus}</strong>.</p><p>Please log in to the management platform to review this update and take any necessary action.</p><p style="font-size:12px;color:#999">This is an automated notification from the Atletica Geneve registration system.</p></div>`
+
+  return { subject, body, htmlBody }
 }

--- a/src/web/pages/collaborator/athlete/modals.tsx
+++ b/src/web/pages/collaborator/athlete/modals.tsx
@@ -57,7 +57,7 @@ export function ConfirmTransitionDialog({ fromStatus, toStatus, athlete, onConfi
 // ── Email preview modal ─────────────────────────────────────────────────────
 
 export function EmailPreviewModal({ emailPreview, onClose }: {
-  emailPreview: { subject: string; body: string }
+  emailPreview: { subject: string; body: string; htmlBody?: string }
   onClose: () => void
 }) {
   const { t } = useTranslation()
@@ -73,7 +73,11 @@ export function EmailPreviewModal({ emailPreview, onClose }: {
           <div className="text-xs text-gray-700">
             <span className="font-medium">{t('emailPreview.subject')}:</span> {emailPreview.subject}
           </div>
-          <pre className="text-xs text-gray-700 whitespace-pre-wrap bg-gray-50 p-3 rounded border">{emailPreview.body}</pre>
+          {emailPreview.htmlBody ? (
+            <div className="text-sm prose prose-sm max-w-none bg-gray-50 p-3 rounded border" dangerouslySetInnerHTML={{ __html: emailPreview.htmlBody }} />
+          ) : (
+            <pre className="text-xs text-gray-700 whitespace-pre-wrap bg-gray-50 p-3 rounded border">{emailPreview.body}</pre>
+          )}
           <div className="flex justify-end">
             <button
               onClick={onClose}

--- a/src/web/pages/manager/RegisterPage.tsx
+++ b/src/web/pages/manager/RegisterPage.tsx
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/react-query'
 import { api, ApiError } from '@web/lib/api'
 import { useAuth } from '@web/lib/auth'
 import { LanguageSwitcher } from '@web/App'
+import { EmailPreviewModal } from '@web/pages/collaborator/athlete/modals'
 import type { Event, EapCity, Country } from '@shared/types'
 
 // Events API returns Event joined with catalog data
@@ -44,6 +45,7 @@ export default function ManagerRegisterPage() {
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
   const [registeredCount, setRegisteredCount] = useState(0)
+  const [emailPreview, setEmailPreview] = useState<{ subject: string; body: string; htmlBody?: string } | null>(null)
   const [expandedRow, setExpandedRow] = useState<string | null>(null)
   const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number; minWidth: number } | null>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
@@ -133,9 +135,13 @@ export default function ManagerRegisterPage() {
         waProfileUrl: r.waProfileUrl || undefined,
         dateOfBirth: r.dateOfBirth || undefined,
       }))
-      const res = await api.post<{ registered: unknown[] }>('/api/v1/athletes/batch', { athletes })
+      const res = await api.post<{ registered: unknown[]; emailPreview?: { subject: string; body: string; htmlBody?: string } }>('/api/v1/athletes/batch', { athletes })
       setRegisteredCount(res.registered.length)
-      setSubmitted(true)
+      if (res.emailPreview) {
+        setEmailPreview(res.emailPreview)
+      } else {
+        setSubmitted(true)
+      }
     } catch (err) {
       setError(err instanceof ApiError ? err.message : t('common.error'))
     } finally {
@@ -286,6 +292,13 @@ export default function ManagerRegisterPage() {
           </div>
         </div>
       </div>
+
+      {emailPreview && (
+        <EmailPreviewModal
+          emailPreview={emailPreview}
+          onClose={() => { setEmailPreview(null); setSubmitted(true) }}
+        />
+      )}
 
       {/* Event selection dropdown rendered via portal to escape overflow clipping */}
       {expandedRow && dropdownPos && expandedRowData && createPortal(


### PR DESCRIPTION
Améliorations du système d'envoi de mails demandées dans l'issue #82

## Changements

- Différenciation inscription (application) vs connexion (login link) avec sujets distincts incluant le nom du meeting
- Tous les mails ont maintenant une version HTML ; le lien magic link est un bouton cliquable
- Les 13 transitions de négociation incluent maintenant un htmlBody
- Email batch manager : texte complet et cordial avec tableau HTML
- Réponse portail athlète : salutation "Dear ATLETICAGENEVE organisation committee" et pronom genré
- Notifications manager créent des interactions avec emailLogId (visibles dans la chronologie)
- EmailPreviewModal affiche le HTML quand disponible
- RegisterPage manager affiche l'EmailPreviewModal après soumission batch

Closes #82

Generated with [Claude Code](https://claude.ai/code)