### PR TITLE
fix: afficher le HTML dans les aperçus email des pages publiques

### DIFF
--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -154,7 +154,7 @@ function HomePage() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
-  const [emailPreview, setEmailPreview] = useState<{ subject: string; body: string } | null>(null)
+  const [emailPreview, setEmailPreview] = useState<{ subject: string; body: string; htmlBody?: string } | null>(null)
 
   // If already logged in, redirect to the right portal
   if (user && !loading) {
@@ -192,7 +192,7 @@ function HomePage() {
     setError('')
     setLoading(true)
     try {
-      const res = await api.post<{ method: string; emailPreview?: { subject: string; body: string } }>(
+      const res = await api.post<{ method: string; emailPreview?: { subject: string; body: string; htmlBody?: string } }>(
         '/api/v1/auth/identify',
         { identifier: email.trim() },
       )
@@ -342,7 +342,11 @@ function HomePage() {
                 <span>{emailPreview.subject}</span>
               </div>
               <hr />
-              <pre className="whitespace-pre-wrap font-sans leading-relaxed">{emailPreview.body}</pre>
+              {emailPreview.htmlBody ? (
+                <div className="text-sm prose prose-sm max-w-none" dangerouslySetInnerHTML={{ __html: emailPreview.htmlBody }} />
+              ) : (
+                <pre className="whitespace-pre-wrap font-sans leading-relaxed">{emailPreview.body}</pre>
+              )}
             </div>
             <button
               onClick={() => setEmailPreview(null)}

--- a/src/web/pages/athlete/RegisterPage.tsx
+++ b/src/web/pages/athlete/RegisterPage.tsx
@@ -23,7 +23,7 @@ export default function AthleteRegisterPage() {
   const [submitted, setSubmitted] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
-  const [emailPreview, setEmailPreview] = useState<{ subject: string; body: string } | null>(null)
+  const [emailPreview, setEmailPreview] = useState<{ subject: string; body: string; htmlBody?: string } | null>(null)
 
   // Form state
   const [form, setForm] = useState({
@@ -101,7 +101,7 @@ export default function AthleteRegisterPage() {
         dopingFree: form.dopingFree,
         participantNotes: form.participantNotes || undefined,
         additionalNotes: form.additionalNotes || undefined,
-      }) as { emailPreview?: { subject: string; body: string } | null }
+      }) as { emailPreview?: { subject: string; body: string; htmlBody?: string } | null }
       setSubmitted(true)
       if (result.emailPreview) {
         setEmailPreview(result.emailPreview)
@@ -139,7 +139,11 @@ export default function AthleteRegisterPage() {
                   <span>{emailPreview.subject}</span>
                 </div>
                 <hr />
-                <pre className="whitespace-pre-wrap font-sans leading-relaxed">{emailPreview.body}</pre>
+                {emailPreview.htmlBody ? (
+                  <div className="text-sm prose prose-sm max-w-none" dangerouslySetInnerHTML={{ __html: emailPreview.htmlBody }} />
+                ) : (
+                  <pre className="whitespace-pre-wrap font-sans leading-relaxed">{emailPreview.body}</pre>
+                )}
               </div>
               <button
                 onClick={() => setEmailPreview(null)}


### PR DESCRIPTION
Correction du bug A1 signalé dans l'issue #82

Les pages publiques (`App.tsx` et `RegisterPage.tsx`) avaient le type `emailPreview` sans `htmlBody`, et rendaient les aperçus email avec `<pre>` au lieu du HTML. Le bouton magic link n'apparaissait donc pas.

Ce PR corrige les deux fichiers pour afficher le HTML quand disponible (avec le bouton cliquable), et revenir au texte brut sinon.

Closes #82

Generated with [Claude Code](https://claude.ai/code)