### PR TITLE
fix: HTML rendering et salutation dans les emails de transition

### DIFF
--- a/src/api/routes/agreements.ts
+++ b/src/api/routes/agreements.ts
@@ -5,7 +5,7 @@ import * as schema from '../db/schema'
 import { agreementSchema } from '@shared/validation'
 import { requireAuth } from '../middleware/auth'
 import { sendEmail, buildTransitionEmail } from '../services/email'
-import { formatAgreementTerms } from '@shared/agreementFormatter'
+import { formatAgreementTerms, formatAgreementTermsHtml } from '@shared/agreementFormatter'
 import { calculateTotalCost } from '../lib/helpers'
 import type { Env } from '../index'
 import type { NegotiationStatus, ParticipationStatus } from '@shared/types'
@@ -199,6 +199,7 @@ agreements.post('/:athleteId/agreements', zValidator('json', agreementSchema), a
   }
 
   const agreementTerms = formatAgreementTerms(agreementForFormat, selectedEventNames, edition.name, 'en')
+  const agreementHtmlTerms = formatAgreementTermsHtml(agreementForFormat, selectedEventNames, edition.name, 'en')
 
   // Build transition email for agreement_sent
   const athleteName = `${ath.firstName} ${ath.lastName}`
@@ -225,6 +226,7 @@ agreements.post('/:athleteId/agreements', zValidator('json', agreementSchema), a
     recipientName,
     organizationName,
     agreementTerms,
+    agreementHtmlTerms,
   })
 
   if (transitionEmail) {
@@ -235,6 +237,7 @@ agreements.post('/:athleteId/agreements', zValidator('json', agreementSchema), a
         to: targetEmail,
         subject: transitionEmail.subject,
         body: transitionEmail.body,
+        htmlBody: transitionEmail.htmlBody,
         relatedAthleteId: athleteId,
       })
     }

--- a/src/api/routes/athletes.ts
+++ b/src/api/routes/athletes.ts
@@ -538,13 +538,17 @@ athletes.patch('/:id/negotiation-status', requireAuth('athlete', 'manager', 'col
     }
   }
 
+  // Staff-initiated → email goes to athlete/manager: use their name
+  // Athlete/manager-initiated → email goes to organisation: use committee name
+  const emailRecipientName = staff ? recipientName : `${meetingName} Organisation Committee`
+
   const transitionEmail = buildTransitionEmail({
     from: currentStatus,
     to: newStatus,
     athleteName,
     meetingName,
     senderName,
-    recipientName,
+    recipientName: emailRecipientName,
     organizationName,
     counterOfferText,
   })

--- a/src/api/services/email.ts
+++ b/src/api/services/email.ts
@@ -132,9 +132,10 @@ export function buildTransitionEmail(params: {
   recipientName: string
   organizationName: string
   agreementTerms?: string
+  agreementHtmlTerms?: string
   counterOfferText?: string
 }): TransitionEmail | null {
-  const { from, to, athleteName, meetingName, senderName, recipientName, organizationName, agreementTerms, counterOfferText } = params
+  const { from, to, athleteName, meetingName, senderName, recipientName, organizationName, agreementTerms, agreementHtmlTerms, counterOfferText } = params
   const key = `${from}__${to}`
 
   const make = (subject: string, body: string): TransitionEmail => ({
@@ -143,15 +144,20 @@ export function buildTransitionEmail(params: {
     htmlBody: textToHtml(body),
   })
 
+  const makeHtml = (subject: string, body: string, htmlBody: string): TransitionEmail => ({ subject, body, htmlBody })
+
   switch (key) {
     case 'to_review__agreement_sent': {
       const termsSection = agreementTerms
         ? `\n\nHere are the terms of our offer:\n\n${agreementTerms}`
         : ''
-      return make(
-        `${meetingName} — Participation Agreement`,
-        `Dear ${recipientName},\n\nWe are pleased to inform you that we have reviewed ${athleteName}'s application for ${meetingName} and are ready to move forward with a participation offer.${termsSection}\n\nPlease let us know your decision at your earliest convenience. Should you have any questions or wish to discuss any aspect of the offer, please do not hesitate to reach out.\n\nKind regards,\n${senderName} — ${organizationName}`,
-      )
+      const subject = `${meetingName} — Participation Agreement`
+      const body = `Dear ${recipientName},\n\nWe are pleased to inform you that we have reviewed ${athleteName}'s application for ${meetingName} and are ready to move forward with a participation offer.${termsSection}\n\nPlease let us know your decision at your earliest convenience. Should you have any questions or wish to discuss any aspect of the offer, please do not hesitate to reach out.\n\nKind regards,\n${senderName} — ${organizationName}`
+      if (agreementHtmlTerms) {
+        const htmlBody = `<div style="font-family:sans-serif;font-size:14px;line-height:1.6;color:#333"><p>Dear ${recipientName},</p><p>We are pleased to inform you that we have reviewed <strong>${athleteName}</strong>'s application for <strong>${meetingName}</strong> and are ready to move forward with a participation offer.</p>${agreementHtmlTerms}<p>Please let us know your decision at your earliest convenience. Should you have any questions or wish to discuss any aspect of the offer, please do not hesitate to reach out.</p><p>Kind regards,<br/>${senderName} — ${organizationName}</p></div>`
+        return makeHtml(subject, body, htmlBody)
+      }
+      return make(subject, body)
     }
     case 'to_review__rejected':
       return make(
@@ -186,10 +192,13 @@ export function buildTransitionEmail(params: {
       const termsSection = agreementTerms
         ? `\n\nHere are the revised terms:\n\n${agreementTerms}`
         : ''
-      return make(
-        `${meetingName} — Updated Participation Agreement`,
-        `Dear ${recipientName},\n\nThank you for your counter-offer regarding ${athleteName}'s participation in ${meetingName}. We have taken your points into consideration and are pleased to send you an updated participation offer.${termsSection}\n\nWe hope this revised proposal meets your expectations. Please do not hesitate to contact us if you have any further questions.\n\nKind regards,\n${senderName} — ${organizationName}`,
-      )
+      const subject = `${meetingName} — Updated Participation Agreement`
+      const body = `Dear ${recipientName},\n\nThank you for your counter-offer regarding ${athleteName}'s participation in ${meetingName}. We have taken your points into consideration and are pleased to send you an updated participation offer.${termsSection}\n\nWe hope this revised proposal meets your expectations. Please do not hesitate to contact us if you have any further questions.\n\nKind regards,\n${senderName} — ${organizationName}`
+      if (agreementHtmlTerms) {
+        const htmlBody = `<div style="font-family:sans-serif;font-size:14px;line-height:1.6;color:#333"><p>Dear ${recipientName},</p><p>Thank you for your counter-offer regarding <strong>${athleteName}</strong>'s participation in <strong>${meetingName}</strong>. We have taken your points into consideration and are pleased to send you an updated participation offer.</p>${agreementHtmlTerms}<p>We hope this revised proposal meets your expectations. Please do not hesitate to contact us if you have any further questions.</p><p>Kind regards,<br/>${senderName} — ${organizationName}</p></div>`
+        return makeHtml(subject, body, htmlBody)
+      }
+      return make(subject, body)
     }
     case 'counter_offer_sent__rejected':
       return make(

--- a/src/shared/agreementFormatter.ts
+++ b/src/shared/agreementFormatter.ts
@@ -171,3 +171,78 @@ export function formatAgreementTerms(
 
   return lines.join('\n')
 }
+
+export function formatAgreementTermsHtml(
+  agreement: AgreementWithHotel,
+  selectedEventNames: string[],
+  meetingName: string,
+  lang: Lang,
+): string {
+  const sentDateStr = formatDate(agreement.sentAt, lang)
+  const title = lang === 'fr' ? "Accord d'invitation" : 'Invitation Agreement'
+  const termsLabel = lang === 'fr' ? "Conditions de l'accord" : 'Agreement terms'
+
+  const rows: string[] = []
+
+  const eventsLabel = lang === 'fr' ? 'Épreuves sélectionnées' : 'Selected events'
+  rows.push(`<tr><td style="padding:5px 12px;font-weight:600;vertical-align:top;color:#555">${eventsLabel}</td><td style="padding:5px 12px">${selectedEventNames.join('<br/>')}</td></tr>`)
+
+  if (agreement.appearanceFee > 0) {
+    const label = lang === 'fr' ? 'Cachet de participation' : 'Appearance fee'
+    rows.push(`<tr><td style="padding:5px 12px;font-weight:600;color:#555">${label}</td><td style="padding:5px 12px">${formatAmount(agreement.appearanceFee, lang)}</td></tr>`)
+  }
+
+  if (agreement.otherCompensation > 0) {
+    const baseLabel = lang === 'fr' ? 'Autre compensation' : 'Other compensation'
+    const label = agreement.otherCompensationDesc ? `${baseLabel} (${agreement.otherCompensationDesc})` : baseLabel
+    rows.push(`<tr><td style="padding:5px 12px;font-weight:600;color:#555">${label}</td><td style="padding:5px 12px">${formatAmount(agreement.otherCompensation, lang)}</td></tr>`)
+  }
+
+  if (agreement.transport > 0) {
+    const label = lang === 'fr' ? 'Indemnité de transport' : 'Transport allowance'
+    rows.push(`<tr><td style="padding:5px 12px;font-weight:600;color:#555">${label}</td><td style="padding:5px 12px">${formatAmount(agreement.transport, lang)}</td></tr>`)
+  }
+
+  if (agreement.transportAirportHotel) {
+    const label = lang === 'fr' ? 'Transport aéroport → hôtel' : 'Airport → hotel transfer'
+    rows.push(`<tr><td style="padding:5px 12px;font-weight:600;color:#555">${label}</td><td style="padding:5px 12px">${lang === 'fr' ? 'inclus' : 'included'}</td></tr>`)
+  }
+
+  if (agreement.transportHotelStadium) {
+    const label = lang === 'fr' ? 'Transport hôtel → stade' : 'Hotel → stadium transfer'
+    rows.push(`<tr><td style="padding:5px 12px;font-weight:600;color:#555">${label}</td><td style="padding:5px 12px">${lang === 'fr' ? 'inclus' : 'included'}</td></tr>`)
+  }
+
+  const nightDays = getActiveDays({ tue: agreement.hotelNightTue, wed: agreement.hotelNightWed, thu: agreement.hotelNightThu, fri: agreement.hotelNightFri, sat: agreement.hotelNightSat, sun: agreement.hotelNightSun }, lang)
+  const dinnerDays = getActiveDays({ tue: agreement.dinnerTue, wed: agreement.dinnerWed, thu: agreement.dinnerThu, fri: agreement.dinnerFri, sat: agreement.dinnerSat, sun: agreement.dinnerSun }, lang)
+
+  if (nightDays.length > 0) {
+    const n = nightDays.length
+    const nightsStr = lang === 'fr' ? `${n} nuit${n > 1 ? 's' : ''}` : `${n} night${n > 1 ? 's' : ''}`
+    const hotelPart = agreement.hotelName ? ` — ${agreement.hotelName}${agreement.hotelRoomType ? ` (${agreement.hotelRoomType})` : ''}` : ''
+    const accomLabel = lang === 'fr' ? 'Hébergement' : 'Accommodation'
+    rows.push(`<tr><td style="padding:5px 12px;font-weight:600;color:#555">${accomLabel}${hotelPart}</td><td style="padding:5px 12px">${nightsStr} : ${nightDays.join(', ')}</td></tr>`)
+  }
+
+  if (dinnerDays.length > 0) {
+    const n = dinnerDays.length
+    const dinnersStr = lang === 'fr' ? `${n} dîner${n > 1 ? 's' : ''}` : `${n} dinner${n > 1 ? 's' : ''}`
+    const dinnersLabel = lang === 'fr' ? 'Dîners' : 'Dinners'
+    rows.push(`<tr><td style="padding:5px 12px;font-weight:600;color:#555">${dinnersLabel}</td><td style="padding:5px 12px">${dinnersStr} : ${dinnerDays.join(', ')}</td></tr>`)
+  }
+
+  if (agreement.stadiumMeals) {
+    const label = lang === 'fr' ? 'Repas au stade' : 'Stadium meals'
+    rows.push(`<tr><td style="padding:5px 12px;font-weight:600;color:#555">${label}</td><td style="padding:5px 12px">${lang === 'fr' ? 'inclus' : 'included'}</td></tr>`)
+  }
+
+  const totalLabel = lang === 'fr' ? 'Total' : 'Total cost'
+  rows.push(`<tr style="border-top:2px solid #ddd;background:#f9f9f9"><td style="padding:8px 12px;font-weight:700">${totalLabel}</td><td style="padding:8px 12px;font-weight:700">${formatAmount(agreement.totalCost, lang)}</td></tr>`)
+
+  if (agreement.notes) {
+    const noteLabel = 'Note'
+    rows.push(`<tr><td style="padding:5px 12px;font-weight:600;color:#555">${noteLabel}</td><td style="padding:5px 12px;font-style:italic">${agreement.notes}</td></tr>`)
+  }
+
+  return `<div style="margin:16px 0"><p style="font-size:13px;color:#666;margin:0 0 6px"><strong>${title}</strong> — v${agreement.version} &middot; ${meetingName} &middot; ${sentDateStr}</p><table style="border-collapse:collapse;width:100%;border:1px solid #e0e0e0;font-size:13px"><thead><tr style="background:#f0f0f0"><th colspan="2" style="padding:7px 12px;text-align:left;font-size:12px;color:#555;border-bottom:1px solid #e0e0e0;font-weight:600;text-transform:uppercase;letter-spacing:.5px">${termsLabel}</th></tr></thead><tbody>${rows.join('')}</tbody></table></div>`
+}

--- a/src/web/pages/collaborator/AthletePage.tsx
+++ b/src/web/pages/collaborator/AthletePage.tsx
@@ -38,7 +38,7 @@ export default function AthletePage() {
     toStatus: NegotiationStatus
     onConfirm: () => void
   } | null>(null)
-  const [emailPreview, setEmailPreview] = useState<{ subject: string; body: string } | null>(null)
+  const [emailPreview, setEmailPreview] = useState<{ subject: string; body: string; htmlBody?: string } | null>(null)
   const [showAgreementForm, setShowAgreementForm] = useState(false)
   const [noteType, setNoteType] = useState<'note' | 'call' | 'email'>('note')
   const [noteContent, setNoteContent] = useState('')
@@ -68,7 +68,7 @@ export default function AthletePage() {
   }
 
   // Propagate email preview from mutations
-  const handleStatusSuccess = (data: { emailPreview?: { subject: string; body: string } } | undefined) => {
+  const handleStatusSuccess = (data: { emailPreview?: { subject: string; body: string; htmlBody?: string } } | undefined) => {
     setConfirmDialog(null)
     if (data?.emailPreview) setEmailPreview(data.emailPreview)
   }

--- a/src/web/pages/collaborator/athlete/useAthleteData.ts
+++ b/src/web/pages/collaborator/athlete/useAthleteData.ts
@@ -35,13 +35,13 @@ export function useAthleteMutations(id: string | undefined) {
 
   const statusMutation = useMutation({
     mutationFn: (status: NegotiationStatus) =>
-      api.patch<{ emailPreview?: { subject: string; body: string } }>(`/api/v1/athletes/${id}/negotiation-status`, { status }),
+      api.patch<{ emailPreview?: { subject: string; body: string; htmlBody?: string } }>(`/api/v1/athletes/${id}/negotiation-status`, { status }),
     onSuccess: invalidate,
   })
 
   const agreementMutation = useMutation({
     mutationFn: (data: AgreementFormDraft) =>
-      api.post<{ emailPreview?: { subject: string; body: string } }>(`/api/v1/athletes/${id}/agreements`, {
+      api.post<{ emailPreview?: { subject: string; body: string; htmlBody?: string } }>(`/api/v1/athletes/${id}/agreements`, {
         ...data,
         appearanceFee: data.appearanceFee === '' ? 0 : data.appearanceFee,
         otherCompensation: data.otherCompensation === '' ? 0 : data.otherCompensation,
@@ -94,7 +94,7 @@ export function useAthleteMutations(id: string | undefined) {
   const counterOfferMutation = useMutation({
     mutationFn: async (text: string) => {
       await api.post(`/api/v1/athletes/${id}/interactions`, { type: 'counter_offer', content: text })
-      return api.patch<{ emailPreview?: { subject: string; body: string } }>(`/api/v1/athletes/${id}/negotiation-status`, { status: 'counter_offer_sent' })
+      return api.patch<{ emailPreview?: { subject: string; body: string; htmlBody?: string } }>(`/api/v1/athletes/${id}/negotiation-status`, { status: 'counter_offer_sent' })
     },
     onSuccess: invalidate,
   })


### PR DESCRIPTION
Corrections des bugs signés dans l'issue #82

## Changements

- Types TypeScript corrigés : `htmlBody` ajouté dans `useAthleteData.ts` et `AthletePage.tsx`
- Ajout de `formatAgreementTermsHtml()` pour un tableau HTML structuré des termes du contrat
- `agreements.ts` passe maintenant `htmlBody` à `sendEmail`
- Salutation corrigée : emails athlète/manager → organisation utilisent maintenant "{meetingName} Organisation Committee"

Closes #82

Generated with [Claude Code](https://claude.ai/code)