### PR TITLE
feat: revamp interaction timeline with role-based filtering and Lucide icons

### DIFF
--- a/src/api/db/migrations/0008_interaction_author_role.sql
+++ b/src/api/db/migrations/0008_interaction_author_role.sql
@@ -1,0 +1,2 @@
+-- Add authorRole to interaction table to track whether action was taken by staff or athlete/manager
+ALTER TABLE interaction ADD COLUMN author_role TEXT NOT NULL DEFAULT 'collaborator';

--- a/src/api/db/schema.ts
+++ b/src/api/db/schema.ts
@@ -239,6 +239,7 @@ export const interaction = sqliteTable('interaction', {
   content: text('content').notNull(),
   authorId: text('author_id').references(() => user.id),
   authorName: text('author_name').notNull(),
+  authorRole: text('author_role').notNull().default('collaborator'),
   emailLogId: text('email_log_id').references(() => emailLog.id),
   createdAt: createdAt(),
 })

--- a/src/api/routes/agreements.ts
+++ b/src/api/routes/agreements.ts
@@ -161,6 +161,8 @@ agreements.post('/:athleteId/agreements', zValidator('json', agreementSchema), a
     content: `Agreement offer v${nextVersion} sent — CHF ${totalCost.toLocaleString()}`,
     authorId: user.id,
     authorName: `${user.firstName} ${user.lastName}`,
+    authorRole: user.role,
+    createdAt: new Date().toISOString(),
   })
 
   // Build the agreement object with hotel info for formatting

--- a/src/api/routes/applications.ts
+++ b/src/api/routes/applications.ts
@@ -186,10 +186,16 @@ applications.patch('/:id/participation-status', zValidator('json', participation
   const id = c.req.param('id')
   const newStatus = c.req.valid('json').participationStatus as ParticipationStatus
 
-  // Get application
+  // Get application with event name for the log
   const apps = await db
-    .select()
+    .select({
+      application: schema.application,
+      catalogName: schema.eventCatalog.name,
+      catalogGender: schema.eventCatalog.gender,
+    })
     .from(schema.application)
+    .innerJoin(schema.event, eq(schema.application.eventId, schema.event.id))
+    .innerJoin(schema.eventCatalog, eq(schema.event.catalogId, schema.eventCatalog.id))
     .where(eq(schema.application.id, id))
     .limit(1)
 
@@ -197,7 +203,8 @@ applications.patch('/:id/participation-status', zValidator('json', participation
     return c.json({ error: 'Application not found' }, 404)
   }
 
-  const app = apps[0]
+  const app = apps[0].application
+  const eventName = `${apps[0].catalogName} ${apps[0].catalogGender === 'M' ? 'Men' : 'Women'}`
   const currentStatus = app.participationStatus as ParticipationStatus
 
   // Block changes when athlete negotiation is confirmed
@@ -230,9 +237,11 @@ applications.patch('/:id/participation-status', zValidator('json', participation
     athleteId: app.athleteId,
     applicationId: id,
     type: 'status_change',
-    content: `Participation status changed to "${newStatus}"`,
+    content: `[${eventName}] Participation status changed from "${currentStatus}" to "${newStatus}"`,
     authorId: user.id,
     authorName: `${user.firstName} ${user.lastName}`,
+    authorRole: user.role,
+    createdAt: new Date().toISOString(),
   })
 
   return c.json({ id, participationStatus: newStatus, previousStatus: currentStatus })

--- a/src/api/routes/athletes.ts
+++ b/src/api/routes/athletes.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { zValidator } from '@hono/zod-validator'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, isNotNull, or, sql } from 'drizzle-orm'
 import * as schema from '../db/schema'
 import { athleteRegistrationSchema, batchAthleteRegistrationSchema, athleteUpdateSchema, negotiationStatusChangeSchema, interactionSchema } from '@shared/validation'
 import { NEGOTIATION_TRANSITIONS, COMMITTEE_EXTRA_TRANSITIONS, ATHLETE_TRANSITIONS } from '@shared/constants'
@@ -87,6 +87,7 @@ athletes.post('/', zValidator('json', athleteRegistrationSchema), async (c) => {
       type: 'status_change',
       content: 'Application submitted',
       authorName: `${data.firstName} ${data.lastName}`,
+      authorRole: 'athlete',
       createdAt: new Date().toISOString(),
     })
   }
@@ -176,6 +177,7 @@ athletes.post('/', zValidator('json', athleteRegistrationSchema), async (c) => {
         type: 'manager_notification',
         content: `Manager ${managerName} notified of new registration`,
         authorName: `${data.firstName} ${data.lastName}`,
+        authorRole: 'athlete',
         emailLogId: notifEmailId,
         createdAt: new Date().toISOString(),
       })
@@ -251,6 +253,7 @@ athletes.post('/batch', requireAuth('manager'), zValidator('json', batchAthleteR
         content: `Application submitted by manager ${user.firstName} ${user.lastName}`,
         authorId: user.id,
         authorName: `${user.firstName} ${user.lastName}`,
+        authorRole: user.role,
         createdAt: new Date().toISOString(),
       })
     }
@@ -291,6 +294,7 @@ athletes.post('/batch', requireAuth('manager'), zValidator('json', batchAthleteR
       content: `Batch registration confirmation sent to manager ${managerName}`,
       authorName: managerName,
       authorId: user.id,
+      authorRole: user.role,
       emailLogId: batchEmailId,
       createdAt: new Date().toISOString(),
     })
@@ -381,11 +385,21 @@ athletes.get('/:id', requireAuth('athlete', 'manager', 'collaborator', 'committe
     ? rawAgreements
     : rawAgreements.map(a => ({ ...a, totalCost: undefined }))
 
-  // Fetch interactions (ordered most recent first)
+  // Fetch interactions (ordered most recent first); athlete/manager only see status changes and emailed entries
+  const interactionWhere = staff
+    ? eq(schema.interaction.athleteId, id)
+    : and(
+        eq(schema.interaction.athleteId, id),
+        or(
+          isNotNull(schema.interaction.emailLogId),
+          eq(schema.interaction.type, 'status_change'),
+          eq(schema.interaction.type, 'email'),
+        ),
+      )
   const interactions = await db
     .select()
     .from(schema.interaction)
-    .where(eq(schema.interaction.athleteId, id))
+    .where(interactionWhere)
     .orderBy(sql`${schema.interaction.createdAt} DESC`)
 
   // Fetch current edition
@@ -589,6 +603,7 @@ athletes.patch('/:id/negotiation-status', requireAuth('athlete', 'manager', 'col
     content: `Negotiation status changed from "${currentStatus}" to "${newStatus}"`,
     authorId: user.id,
     authorName: senderName,
+    authorRole: user.role,
     emailLogId,
     createdAt: new Date().toISOString(),
   })
@@ -683,6 +698,7 @@ athletes.post('/:id/interactions', requireAuth('athlete', 'manager', 'collaborat
     content,
     authorId: user.id,
     authorName: `${user.firstName} ${user.lastName}`,
+    authorRole: user.role,
     createdAt: new Date().toISOString(),
   })
 

--- a/src/api/routes/portal.ts
+++ b/src/api/routes/portal.ts
@@ -132,6 +132,8 @@ portal.post('/athlete/:athleteId/respond', requireAuth('athlete', 'manager'), zV
       content: `Agreement accepted by ${user.firstName} ${user.lastName}`,
       authorId: user.id,
       authorName: `${user.firstName} ${user.lastName}`,
+      authorRole: user.role,
+      createdAt: new Date().toISOString(),
     })
 
   } else if (action === 'reject') {
@@ -149,6 +151,8 @@ portal.post('/athlete/:athleteId/respond', requireAuth('athlete', 'manager'), zV
       content: `Agreement rejected by ${user.firstName} ${user.lastName}`,
       authorId: user.id,
       authorName: `${user.firstName} ${user.lastName}`,
+      authorRole: user.role,
+      createdAt: new Date().toISOString(),
     })
 
   } else if (action === 'withdraw') {
@@ -166,6 +170,8 @@ portal.post('/athlete/:athleteId/respond', requireAuth('athlete', 'manager'), zV
       content: `Withdrawn by ${user.firstName} ${user.lastName}`,
       authorId: user.id,
       authorName: `${user.firstName} ${user.lastName}`,
+      authorRole: user.role,
+      createdAt: new Date().toISOString(),
     })
 
   } else if (action === 'counter_offer') {
@@ -291,6 +297,8 @@ portal.post('/athlete/:athleteId/respond', requireAuth('athlete', 'manager'), zV
       content: `Counter-offer v${nextVersion} submitted by ${user.firstName} ${user.lastName}`,
       authorId: user.id,
       authorName: `${user.firstName} ${user.lastName}`,
+      authorRole: user.role,
+      createdAt: new Date().toISOString(),
     })
 
     // Update negotiation status

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -35,6 +35,7 @@ export type InteractionType =
   | 'status_change'
   | 'agreement'
   | 'counter_offer'
+  | 'manager_notification'
 
 // ── Domain entities ───────────────────────────────────────────────────────────
 
@@ -253,6 +254,7 @@ export interface Interaction {
   content: string
   authorId: string | null
   authorName: string
+  authorRole: UserRole
   emailLogId: string | null
   createdAt: string
 }

--- a/src/web/pages/collaborator/athlete/NegotiationTab.tsx
+++ b/src/web/pages/collaborator/athlete/NegotiationTab.tsx
@@ -135,7 +135,7 @@ export function NegotiationTab({ athlete, isStaff, isAthleteOrManager, canSendAg
           {athlete.interactions.length === 0 ? (
             <p className="text-xs text-gray-400">{t('collaborator.noInteractions')}</p>
           ) : (
-            <div className="space-y-3 max-h-96 overflow-y-auto">
+            <div className="max-h-96 overflow-y-auto divide-y divide-gray-100">
               {athlete.interactions.map(interaction => (
                 <InteractionCard key={interaction.id} interaction={interaction} onViewEmail={onViewEmail} />
               ))}

--- a/src/web/pages/collaborator/athlete/components.tsx
+++ b/src/web/pages/collaborator/athlete/components.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { ArrowRightLeft, FileText, CornerUpLeft, PenLine, Phone, Mail, Bell } from 'lucide-react'
 import { formatAgreementTerms } from '@shared/agreementFormatter'
 import { inputCls } from '@web/lib/ui-constants'
 import type { Athlete, Agreement, Interaction } from '@shared/types'
@@ -198,12 +199,15 @@ export function AgreementCard({
 
 // ── CounterOfferCard ────────────────────────────────────────────────────────
 
+const parseDate = (d: string) =>
+  new Date(d.includes('T') ? d : d.replace(' ', 'T') + 'Z')
+
 export function CounterOfferCard({ interaction }: { interaction: Interaction }) {
   return (
     <div className="p-3 rounded border border-rose-200 bg-rose-50 text-xs">
       <div className="flex justify-between mb-1">
         <span className="font-semibold text-rose-700">{interaction.authorName}</span>
-        <span className="text-gray-500">{new Date(interaction.createdAt).toLocaleDateString()}</span>
+        <span className="text-gray-500">{parseDate(interaction.createdAt).toLocaleDateString()}</span>
       </div>
       <p className="text-gray-700 whitespace-pre-wrap">{interaction.content}</p>
     </div>
@@ -212,45 +216,56 @@ export function CounterOfferCard({ interaction }: { interaction: Interaction }) 
 
 // ── InteractionCard ─────────────────────────────────────────────────────────
 
+const isAthleteManagerRole = (role: string) => role === 'athlete' || role === 'manager'
+
+function InteractionIcon({ type, authorRole }: { type: string; authorRole: string }) {
+  const byAthlete = isAthleteManagerRole(authorRole)
+  const cls = 'w-4 h-4 shrink-0'
+
+  switch (type) {
+    case 'status_change':
+      return <ArrowRightLeft className={`${cls} ${byAthlete ? 'text-orange-500' : 'text-blue-500'}`} />
+    case 'agreement':
+      return <FileText className={`${cls} text-green-500`} />
+    case 'counter_offer':
+      return <CornerUpLeft className={`${cls} text-purple-500`} />
+    case 'note':
+      return <PenLine className={`${cls} text-gray-500`} />
+    case 'call':
+      return <Phone className={`${cls} text-orange-500`} />
+    case 'email':
+      return <Mail className={`${cls} text-indigo-500`} />
+    case 'manager_notification':
+      return <Bell className={`${cls} text-yellow-500`} />
+    default:
+      return <ArrowRightLeft className={`${cls} text-gray-400`} />
+  }
+}
+
 export function InteractionCard({ interaction, onViewEmail }: { interaction: Interaction; onViewEmail?: (emailLogId: string) => void }) {
   const { t } = useTranslation()
-  const typeIcons: Record<string, string> = {
-    status_change: '●',
-    agreement: '■',
-    counter_offer: '◆',
-    note: '✎',
-    call: '☎',
-    email: '✉',
-  }
-
-  const typeColors: Record<string, string> = {
-    status_change: 'text-blue-500',
-    agreement: 'text-green-500',
-    counter_offer: 'text-purple-500',
-    note: 'text-gray-500',
-    call: 'text-orange-500',
-    email: 'text-indigo-500',
-  }
-
   const hasEmail = !!interaction.emailLogId
   const clickable = hasEmail && onViewEmail
 
   return (
-    <div
-      className={`flex gap-2 ${clickable ? 'cursor-pointer hover:bg-gray-50 rounded p-1 -m-1' : ''}`}
-      onClick={clickable ? () => onViewEmail(interaction.emailLogId!) : undefined}
-    >
-      <span className={`${typeColors[interaction.type] ?? 'text-gray-400'} mt-0.5 shrink-0`}>
-        {typeIcons[interaction.type] ?? '●'}
-      </span>
+    <div className={`flex gap-2 py-2 ${hasEmail ? 'border-l-2 border-indigo-400 pl-2' : 'pl-0'}`}>
+      <div className="mt-0.5">
+        <InteractionIcon type={interaction.type} authorRole={interaction.authorRole} />
+      </div>
       <div className="flex-1 min-w-0">
-        <p className="text-xs text-gray-900">
-          {interaction.content}
-          {hasEmail && <span className="ml-1 text-indigo-500" title={t('common.viewEmail')}>✉</span>}
+        <p className="text-xs text-gray-500 font-medium mb-0.5">
+          {parseDate(interaction.createdAt).toLocaleString()} — {interaction.authorName}
         </p>
-        <p className="text-[10px] text-gray-400 mt-0.5">
-          {interaction.authorName} — {new Date(interaction.createdAt).toLocaleString()}
-        </p>
+        <p className="text-xs text-gray-900">{interaction.content}</p>
+        {clickable && (
+          <button
+            onClick={() => onViewEmail(interaction.emailLogId!)}
+            className="mt-1 flex items-center gap-1 text-xs text-indigo-600 hover:text-indigo-800 bg-indigo-50 hover:bg-indigo-100 px-2 py-0.5 rounded"
+          >
+            <Mail className="w-3 h-3" />
+            {t('common.viewEmail')}
+          </button>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
Closes #88

## Summary

- Add `authorRole` column to interaction table (migration 0008) to track whether each event was triggered by staff or athlete/manager
- Filter interaction timeline for athlete/manager view: only status changes, email entries, and entries with an associated email are shown
- Replace Unicode glyphs with Lucide icons; status_change icon color signals origin (blue = staff, orange = athlete/manager)
- Associated email is now prominently shown with an indigo left border and a "View email" button
- Fix UTC timestamp parsing bug; timestamp is now displayed at the top of each card
- Enrich participation status change log with event name and previous status

## Test plan

- [ ] Apply migration locally and verify existing interactions are not affected
- [ ] Log in as staff: verify all interaction types are visible, icons and colors are correct
- [ ] Log in as athlete/manager: verify only status changes and emailed entries are shown
- [ ] Verify timestamps are consistent (no more UTC+2 offset)
- [ ] Verify email button opens the correct email modal

Generated with [Claude Code](https://claude.ai/code)