### PR TITLE
fix: timeline bugs — agreement email link and participation status filter

### DIFF
--- a/src/api/routes/agreements.ts
+++ b/src/api/routes/agreements.ts
@@ -154,17 +154,6 @@ agreements.post('/:athleteId/agreements', zValidator('json', agreementSchema), a
     .set({ negotiationStatus: 'agreement_sent', updatedAt: now })
     .where(eq(schema.athlete.id, athleteId))
 
-  // Log interaction
-  await db.insert(schema.interaction).values({
-    athleteId,
-    type: 'agreement',
-    content: `Agreement offer v${nextVersion} sent — CHF ${totalCost.toLocaleString()}`,
-    authorId: user.id,
-    authorName: `${user.firstName} ${user.lastName}`,
-    authorRole: user.role,
-    createdAt: new Date().toISOString(),
-  })
-
   // Build the agreement object with hotel info for formatting
   const agreementForFormat = {
     id: agreementId,
@@ -231,10 +220,11 @@ agreements.post('/:athleteId/agreements', zValidator('json', agreementSchema), a
     agreementHtmlTerms,
   })
 
+  let emailLogId: string | null = null
   if (transitionEmail) {
     const targetEmail = ath.athleteEmail ?? managerEmail
     if (targetEmail) {
-      await sendEmail({
+      emailLogId = await sendEmail({
         db,
         to: targetEmail,
         subject: transitionEmail.subject,
@@ -244,6 +234,18 @@ agreements.post('/:athleteId/agreements', zValidator('json', agreementSchema), a
       })
     }
   }
+
+  // Log interaction after email so we can link the emailLogId
+  await db.insert(schema.interaction).values({
+    athleteId,
+    type: 'agreement',
+    content: `Agreement offer v${nextVersion} sent — CHF ${totalCost.toLocaleString()}`,
+    authorId: user.id,
+    authorName: `${user.firstName} ${user.lastName}`,
+    authorRole: user.role,
+    emailLogId,
+    createdAt: new Date().toISOString(),
+  })
 
   return c.json({
     id: agreementId,

--- a/src/api/routes/athletes.ts
+++ b/src/api/routes/athletes.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { zValidator } from '@hono/zod-validator'
-import { and, eq, isNotNull, or, sql } from 'drizzle-orm'
+import { and, eq, isNotNull, isNull, or, sql } from 'drizzle-orm'
 import * as schema from '../db/schema'
 import { athleteRegistrationSchema, batchAthleteRegistrationSchema, athleteUpdateSchema, negotiationStatusChangeSchema, interactionSchema } from '@shared/validation'
 import { NEGOTIATION_TRANSITIONS, COMMITTEE_EXTRA_TRANSITIONS, ATHLETE_TRANSITIONS } from '@shared/constants'
@@ -392,7 +392,10 @@ athletes.get('/:id', requireAuth('athlete', 'manager', 'collaborator', 'committe
         eq(schema.interaction.athleteId, id),
         or(
           isNotNull(schema.interaction.emailLogId),
-          eq(schema.interaction.type, 'status_change'),
+          and(
+            eq(schema.interaction.type, 'status_change'),
+            isNull(schema.interaction.applicationId),
+          ),
           eq(schema.interaction.type, 'email'),
         ),
       )


### PR DESCRIPTION
Closes #88

## Summary

- **agreements.ts**: déplacement de l'insertion de l'interaction après l'envoi de l'email, afin de stocker l'emailLogId dans l'enregistrement de timeline
- **athletes.ts**: restriction du filtre status_change (vue athlète/manager) aux seuls enregistrements où applicationId IS NULL (changements de statut de négociation uniquement)

## Test plan

- [ ] Envoyer un agreement en tant que staff : vérifier que l'enregistrement de timeline est lié à l'email (icône mail visible, bouton fonctionnel)
- [ ] Se connecter en tant qu'athlète/manager : vérifier que l'enregistrement d'agreement apparaît dans la timeline
- [ ] Vérifier que les changements de statut de participation n'apparaissent plus dans la timeline athlète/manager
- [ ] Vérifier que les changements de statut de négociation restent visibles pour l'athlète/manager

Generated with [Claude Code](https://claude.ai/code)