### PR TITLE
fix: include counter_offer in athlete/manager timeline filter

### DIFF
--- a/src/api/routes/athletes.ts
+++ b/src/api/routes/athletes.ts
@@ -385,7 +385,7 @@ athletes.get('/:id', requireAuth('athlete', 'manager', 'collaborator', 'committe
     ? rawAgreements
     : rawAgreements.map(a => ({ ...a, totalCost: undefined }))
 
-  // Fetch interactions (ordered most recent first); athlete/manager only see status changes and emailed entries
+  // Fetch interactions (ordered most recent first); athlete/manager only see status changes, counter-offers, and emailed entries
   const interactionWhere = staff
     ? eq(schema.interaction.athleteId, id)
     : and(
@@ -397,6 +397,7 @@ athletes.get('/:id', requireAuth('athlete', 'manager', 'collaborator', 'committe
             isNull(schema.interaction.applicationId),
           ),
           eq(schema.interaction.type, 'email'),
+          eq(schema.interaction.type, 'counter_offer'),
         ),
       )
   const interactions = await db


### PR DESCRIPTION
Closes #88

## Summary

- **athletes.ts**: ajout du type `counter_offer` dans le filtre des interactions pour les utilisateurs athlète/manager, afin que les boîtes roses de contre-offres apparaissent dans la colonne gauche de l'onglet Agreement & Négociation

## Test plan

- [ ] Se connecter en tant qu'athlète/manager : vérifier que les boîtes roses de contre-offres apparaissent dans la colonne gauche
- [ ] Vérifier que les accords (agreements) restent visibles
- [ ] Vérifier que les notes internes du staff ne sont pas visibles

Generated with [Claude Code](https://claude.ai/code)