### PR TITLE
fix: EAP City field shows dropdown from reference table

### DIFF
--- a/src/web/pages/collaborator/AthletePage.tsx
+++ b/src/web/pages/collaborator/AthletePage.tsx
@@ -28,7 +28,7 @@ export default function AthletePage() {
   const navigate = useNavigate()
 
   // ── Data ───────────────────────────────���──────────────────────────────
-  const { athlete, isLoading, staffUsers, allRooms } = useAthleteData(id)
+  const { athlete, isLoading, staffUsers, allRooms, eapCities } = useAthleteData(id)
   const mutations = useAthleteMutations(id)
 
   // ── UI state ───────────────��──────────────────────────────────────────
@@ -470,6 +470,7 @@ export default function AthletePage() {
             isStaff={!!isStaff}
             isAthleteOrManager={isAthleteOrManager}
             staffUsers={staffUsers}
+            eapCities={eapCities}
             mutations={{
               athleteUpdate: mutations.athleteUpdateMutation,
               internalNotes: mutations.internalNotesMutation,

--- a/src/web/pages/collaborator/athlete/PersonalTab.tsx
+++ b/src/web/pages/collaborator/athlete/PersonalTab.tsx
@@ -1,15 +1,16 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { inputCls } from '@web/lib/ui-constants'
-import type { AthleteDetail } from '@shared/types'
+import type { AthleteDetail, EapCity } from '@shared/types'
 import type { FieldDef, StaffUser } from './types'
 import { CollapsibleSection, FieldReadOnly, AthleteFieldEditor, SelectorAssign } from './components'
 
-export function PersonalTab({ athlete, isStaff, isAthleteOrManager, staffUsers, mutations }: {
+export function PersonalTab({ athlete, isStaff, isAthleteOrManager, staffUsers, eapCities, mutations }: {
   athlete: AthleteDetail
   isStaff: boolean
   isAthleteOrManager: boolean
   staffUsers: StaffUser[]
+  eapCities: EapCity[]
   mutations: {
     athleteUpdate: { mutate: (data: Record<string, unknown>, options?: { onSuccess?: () => void }) => void; isPending: boolean; error: Error | null }
     internalNotes: { mutate: (notes: string) => void; isPending: boolean }
@@ -41,7 +42,10 @@ export function PersonalTab({ athlete, isStaff, isAthleteOrManager, staffUsers, 
     { key: 'distanceFromGva', label: t('athlete.distanceFromGva'), type: 'number' },
     { key: 'isEap', label: t('athlete.eapMember'), type: 'checkbox' },
     { key: 'isSwiss', label: t('athlete.swiss'), type: 'checkbox' },
-    { key: 'eapCity', label: t('athlete.eapCity'), type: 'text' },
+    { key: 'eapCity', label: t('athlete.eapCity'), type: 'select', options: [
+      { value: '', label: '—' },
+      ...eapCities.map(c => ({ value: c.id, label: c.name })),
+    ]},
   ]
 
   const athleteIdentityFields: FieldDef[] = identityFields.filter(f =>

--- a/src/web/pages/collaborator/athlete/useAthleteData.ts
+++ b/src/web/pages/collaborator/athlete/useAthleteData.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { api } from '@web/lib/api'
 import { useAuth } from '@web/lib/auth'
-import type { AthleteDetail, NegotiationStatus } from '@shared/types'
+import type { AthleteDetail, NegotiationStatus, EapCity } from '@shared/types'
 import type { HotelWithRooms, StaffUser, AgreementFormDraft } from './types'
 
 export function useAthleteData(id: string | undefined) {
@@ -22,9 +22,14 @@ export function useAthleteData(id: string | undefined) {
     queryFn: () => api.get('/api/v1/users?role=collaborator,committee'),
   })
 
+  const { data: eapCities = [] } = useQuery<EapCity[]>({
+    queryKey: ['eap-cities'],
+    queryFn: () => api.get('/api/v1/eap-cities'),
+  })
+
   const allRooms = hotels.flatMap(h => h.rooms.map(r => ({ ...r, hotelName: h.name })))
 
-  return { athlete, isLoading, hotels, staffUsers, allRooms }
+  return { athlete, isLoading, hotels, staffUsers, allRooms, eapCities }
 }
 
 export function useAthleteMutations(id: string | undefined) {


### PR DESCRIPTION
Fixes #3

The `eapCity` field on the athlete edit form was a free-text input, but the DB column stores a UUID foreign key to the `eap_city` reference table. This caused two bugs:
- No dropdown list was shown to pick from existing EAP cities
- Typing a city name and saving produced a "Request failed" error due to FK constraint violation

The fix loads EAP cities from the API and renders a select dropdown (matching the registration page behaviour).

Generated with [Claude Code](https://claude.ai/code)