### PR TITLE
fix: popup athlètes confirmés visible pour tous les rôles

### DIFF
--- a/src/api/routes/portal.ts
+++ b/src/api/routes/portal.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { zValidator } from '@hono/zod-validator'
-import { eq, or, and, desc, max } from 'drizzle-orm'
+import { eq, or, and, desc, max, isNull, inArray } from 'drizzle-orm'
 import * as schema from '../db/schema'
 import { portalRespondSchema } from '@shared/validation'
 import { requireAuth } from '../middleware/auth'
@@ -10,6 +10,51 @@ import type { Env } from '../index'
 import type { NegotiationStatus } from '@shared/types'
 
 const portal = new Hono<Env>()
+
+// ── Confirmed athletes for an event (all authenticated roles) ─────────────────
+
+// GET /portal/events/:eventId/confirmed-athletes — list confirmed athletes for an event
+// Used by the hover popup on the athlete page, accessible to all roles
+portal.get('/events/:eventId/confirmed-athletes', requireAuth('athlete', 'manager', 'collaborator', 'committee'), async (c) => {
+  const db = c.get('db')
+  const eventId = c.req.param('eventId')
+
+  const rows = await db
+    .select({
+      applicationId: schema.application.id,
+      athleteId: schema.athlete.id,
+      firstName: schema.athlete.firstName,
+      lastName: schema.athlete.lastName,
+    })
+    .from(schema.application)
+    .innerJoin(schema.athlete, eq(schema.application.athleteId, schema.athlete.id))
+    .where(and(
+      eq(schema.application.eventId, eventId),
+      eq(schema.athlete.negotiationStatus, 'confirmed'),
+      isNull(schema.athlete.archivedAt),
+    ))
+
+  const athleteIds = rows.map(r => r.athleteId)
+  const waPerfs = athleteIds.length > 0
+    ? await db
+        .select({ athleteId: schema.waPerformance.athleteId, seasonBest: schema.waPerformance.seasonBest })
+        .from(schema.waPerformance)
+        .where(and(
+          inArray(schema.waPerformance.athleteId, athleteIds),
+          eq(schema.waPerformance.eventId, eventId),
+        ))
+    : []
+  const waPerfMap = new Map(waPerfs.map(wp => [wp.athleteId, wp.seasonBest]))
+
+  const result = rows.map(r => ({
+    id: r.applicationId,
+    firstName: r.firstName,
+    lastName: r.lastName,
+    seasonBest: waPerfMap.get(r.athleteId) ?? null,
+  }))
+
+  return c.json(result)
+})
 
 // ── Athlete portal ───────────────────────────────────────────────────────────
 

--- a/src/web/pages/collaborator/athlete/BannerEventRow.tsx
+++ b/src/web/pages/collaborator/athlete/BannerEventRow.tsx
@@ -5,7 +5,6 @@ import { computeScore } from '@shared/scoring'
 import { formatPerf } from '@web/lib/ui-constants'
 import { NIGHT_LABELS, DINNER_LABELS } from '@shared/constants'
 import type { AthleteDetail, ApplicationForAthlete, EditionCosts, Agreement } from '@shared/types'
-import type { ApplicationRow } from './types'
 
 // ── ScoringPopup ────────────────────────────────────────────────────────────
 
@@ -76,14 +75,21 @@ export function ScoringPopup({ app, athlete, edition, t, style }: {
 
 // ── ConfirmedAthletesPopup ──────────────────────────────────────────────────
 
+type ConfirmedAthleteEntry = {
+  id: string
+  firstName: string
+  lastName: string
+  seasonBest: number | null
+}
+
 function ConfirmedAthletesPopup({ eventId, discipline, t }: {
   eventId: string
   discipline: string
   t: (key: string) => string
 }) {
-  const { data: confirmed = [], isLoading } = useQuery<ApplicationRow[]>({
+  const { data: confirmed = [], isLoading } = useQuery<ConfirmedAthleteEntry[]>({
     queryKey: ['confirmed-athletes', eventId],
-    queryFn: () => api.get(`/api/v1/applications?eventId=${eventId}&negotiationStatus=confirmed`),
+    queryFn: () => api.get(`/api/v1/portal/events/${eventId}/confirmed-athletes`),
     staleTime: 60_000,
   })
 
@@ -98,8 +104,8 @@ function ConfirmedAthletesPopup({ eventId, discipline, t }: {
         <div className="space-y-1">
           {[...confirmed]
             .sort((a, b) => {
-              const sb1 = a.waPerformance?.seasonBest ?? a.seasonBest ?? null
-              const sb2 = b.waPerformance?.seasonBest ?? b.seasonBest ?? null
+              const sb1 = a.seasonBest
+              const sb2 = b.seasonBest
               if (sb1 == null && sb2 == null) return 0
               if (sb1 == null) return 1
               if (sb2 == null) return -1
@@ -107,9 +113,9 @@ function ConfirmedAthletesPopup({ eventId, discipline, t }: {
             })
             .map(a => (
               <div key={a.id} className="flex justify-between text-gray-700">
-                <span>{a.athlete.lastName}, {a.athlete.firstName}</span>
+                <span>{a.lastName}, {a.firstName}</span>
                 <span className="font-mono text-gray-500">
-                  {formatPerf(a.waPerformance?.seasonBest ?? a.seasonBest ?? null, discipline)}
+                  {formatPerf(a.seasonBest, discipline)}
                 </span>
               </div>
             ))}


### PR DESCRIPTION
Correction du bug #98 : la popup affichant les athlètes confirmés pour une épreuve retournait "No confirmed athlete yet" pour les athlètes et managers.

L'endpoint `/api/v1/applications` était réservé aux rôles collaborator/committee. Un nouvel endpoint `GET /api/v1/portal/events/:eventId/confirmed-athletes` accessible à tous les rôles authentifiés a été ajouté.

Fixes #98

Generated with [Claude Code](https://claude.ai/code)