### PR TITLE
feat: Results page for grouped placement entry (#100)

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -21,6 +21,7 @@ import hotelRoomRoutes from './routes/hotel-rooms'
 import emailRoutes from './routes/emails'
 import userRoutes from './routes/users'
 import paymentRoutes from './routes/payments'
+import resultRoutes from './routes/results'
 
 export type Env = {
   Bindings: {
@@ -78,5 +79,6 @@ app.route('/api/v1/hotel-rooms', hotelRoomRoutes)
 app.route('/api/v1/emails', emailRoutes)
 app.route('/api/v1/users', userRoutes)
 app.route('/api/v1/payments', paymentRoutes)
+app.route('/api/v1/results', resultRoutes)
 
 export default app

--- a/src/api/routes/results.ts
+++ b/src/api/routes/results.ts
@@ -1,0 +1,111 @@
+import { Hono } from 'hono'
+import { eq, and, isNull, inArray } from 'drizzle-orm'
+import * as schema from '../db/schema'
+import { requireAuth } from '../middleware/auth'
+import type { Env } from '../index'
+import type { ResultAthleteEntry, ResultEventEntry, ResultsResponse } from '@shared/types'
+
+const results = new Hono<Env>()
+
+results.use('*', requireAuth('committee'))
+
+function getPrizeMoney(event: typeof schema.event.$inferSelect, placement: number | null): number {
+  if (!placement || placement < 1 || placement > 8) return 0
+  const fields: (keyof typeof schema.event.$inferSelect)[] = [
+    'prizeMoney1st', 'prizeMoney2nd', 'prizeMoney3rd', 'prizeMoney4th',
+    'prizeMoney5th', 'prizeMoney6th', 'prizeMoney7th', 'prizeMoney8th',
+  ]
+  const field = fields[placement - 1]
+  return field ? (event[field] as number) ?? 0 : 0
+}
+
+// ── GET /results — events with their confirmed athletes and placements ─────────
+
+results.get('/', async (c) => {
+  const db = c.get('db')
+
+  const editions = await db.select().from(schema.edition).limit(1)
+  const edition = editions[0]
+  if (!edition) return c.json({ currency: 'CHF', events: [] } )
+
+  const currency = edition.currency ?? 'CHF'
+
+  const eventRows = await db
+    .select({ event: schema.event, catalog: schema.eventCatalog })
+    .from(schema.event)
+    .innerJoin(schema.eventCatalog, eq(schema.event.catalogId, schema.eventCatalog.id))
+    .where(eq(schema.event.editionId, edition.id))
+
+  if (eventRows.length === 0) return c.json({ currency, events: [] } )
+
+  const eventIds = eventRows.map(r => r.event.id)
+
+  const confirmedAthletes = await db
+    .select()
+    .from(schema.athlete)
+    .where(
+      and(
+        eq(schema.athlete.negotiationStatus, 'confirmed'),
+        isNull(schema.athlete.archivedAt),
+      )
+    )
+
+  const athleteIds = confirmedAthletes.map(a => a.id)
+  const athleteMap = new Map(confirmedAthletes.map(a => [a.id, a]))
+
+  const appRows = athleteIds.length > 0
+    ? await db
+      .select()
+      .from(schema.application)
+      .where(
+        and(
+          inArray(schema.application.athleteId, athleteIds),
+          inArray(schema.application.eventId, eventIds),
+        )
+      )
+    : []
+
+  const appsByEvent = new Map<string, typeof appRows>()
+  for (const app of appRows) {
+    if (!appsByEvent.has(app.eventId)) appsByEvent.set(app.eventId, [])
+    appsByEvent.get(app.eventId)!.push(app)
+  }
+
+  const events: ResultEventEntry[] = eventRows.map(({ event, catalog }) => {
+    const eventName = `${catalog.name} ${catalog.gender === 'M' ? 'Men' : 'Women'}`
+
+    const prizeFields = [
+      event.prizeMoney1st, event.prizeMoney2nd, event.prizeMoney3rd, event.prizeMoney4th,
+      event.prizeMoney5th, event.prizeMoney6th, event.prizeMoney7th, event.prizeMoney8th,
+    ]
+    const prizeSlots = prizeFields
+      .map((amount, i) => ({ place: i + 1, amount: amount ?? 0 }))
+      .filter(s => s.amount > 0)
+
+    const apps = appsByEvent.get(event.id) ?? []
+    const athletes: ResultAthleteEntry[] = apps.map(app => {
+      const ath = athleteMap.get(app.athleteId)!
+      return {
+        applicationId: app.id,
+        athleteId: app.athleteId,
+        athleteFirstName: ath.firstName,
+        athleteLastName: ath.lastName,
+        finalPlacement: app.finalPlacement,
+        prizeMoney: getPrizeMoney(event, app.finalPlacement),
+      }
+    }).sort((a, b) => {
+      if (a.finalPlacement != null && b.finalPlacement != null) return a.finalPlacement - b.finalPlacement
+      if (a.finalPlacement != null) return -1
+      if (b.finalPlacement != null) return 1
+      return a.athleteLastName.localeCompare(b.athleteLastName)
+    })
+
+    return { eventId: event.id, eventName, prizeSlots, athletes }
+  })
+
+  events.sort((a, b) => a.eventName.localeCompare(b.eventName))
+
+  return c.json({ currency, events } )
+})
+
+export default results

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -71,6 +71,7 @@
     "hotelRooms": "Hotel Rooms",
     "emailLog": "Email Log",
     "candidates": "Candidates",
+    "results": "Results",
     "payments": "Payments"
   },
   "status": {
@@ -467,5 +468,16 @@
     "ibanPlaceholder": "e.g. CH56 0483 5012 3456 7800 9",
     "ibanSaved": "IBAN saved",
     "ibanHint": "Your IBAN is needed to process your payment. It will be included in the payment proforma sent by the organisation."
+  },
+  "results": {
+    "title": "Results",
+    "subtitle": "Enter final placements for confirmed athletes, grouped by event",
+    "athlete": "Athlete",
+    "placement": "Placement",
+    "prizeMoney": "Prize money",
+    "prizeMoneyLegend": "Prize money",
+    "place": "Place",
+    "noEvents": "No events found for the current edition.",
+    "noAthletes": "No confirmed athletes registered for this event."
   }
 }

--- a/src/shared/i18n/fr.json
+++ b/src/shared/i18n/fr.json
@@ -71,6 +71,7 @@
     "hotelRooms": "Chambres d'hôtel",
     "emailLog": "Journal des emails",
     "candidates": "Candidats",
+    "results": "Résultats",
     "payments": "Paiements"
   },
   "status": {
@@ -467,5 +468,16 @@
     "ibanPlaceholder": "ex. CH56 0483 5012 3456 7800 9",
     "ibanSaved": "IBAN enregistré",
     "ibanHint": "Votre IBAN est nécessaire pour effectuer le paiement. Il sera inclus dans la proforma envoyée par l'organisation."
+  },
+  "results": {
+    "title": "Résultats",
+    "subtitle": "Saisissez les classements finaux des athlètes confirmés, par épreuve",
+    "athlete": "Athlète",
+    "placement": "Classement",
+    "prizeMoney": "Prize money",
+    "prizeMoneyLegend": "Prize money",
+    "place": "Place",
+    "noEvents": "Aucune épreuve trouvée pour l'édition en cours.",
+    "noAthletes": "Aucun athlète confirmé inscrit à cette épreuve."
   }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -386,3 +386,26 @@ export interface PaymentEntry {
   paymentDate: string | null
   currency: string
 }
+
+// ── Results ───────────────────────────────────────────────────────────────────
+
+export interface ResultAthleteEntry {
+  applicationId: string
+  athleteId: string
+  athleteFirstName: string
+  athleteLastName: string
+  finalPlacement: number | null
+  prizeMoney: number
+}
+
+export interface ResultEventEntry {
+  eventId: string
+  eventName: string
+  prizeSlots: { place: number; amount: number }[]
+  athletes: ResultAthleteEntry[]
+}
+
+export interface ResultsResponse {
+  currency: string
+  events: ResultEventEntry[]
+}

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -21,6 +21,7 @@ import HotelRoomsPage from '@web/pages/committee/HotelRoomsPage'
 import EmailLogPage from '@web/pages/committee/EmailLogPage'
 import EventsPage from '@web/pages/committee/EventsPage'
 import PaymentsPage from '@web/pages/committee/PaymentsPage'
+import ResultsPage from '@web/pages/committee/ResultsPage'
 import { api, ApiError } from '@web/lib/api'
 import type { ReactNode } from 'react'
 import type { UserRole } from '@shared/types'
@@ -89,6 +90,7 @@ const COMMITTEE_NAV: NavItem[] = [
   { to: '/committee/hotel-rooms', key: 'nav.hotelRooms' },
   { to: '/committee/emails', key: 'nav.emailLog' },
   { to: '/committee/candidates', key: 'nav.candidates', activePrefix: '/committee/athletes/' },
+  { to: '/committee/results', key: 'nav.results' },
   { to: '/committee/payments', key: 'nav.payments' },
 ]
 
@@ -432,6 +434,7 @@ export default function App() {
               <Route path="emails" element={<EmailLogPage />} />
               <Route path="candidates" element={<CandidatesPage />} />
               <Route path="athletes/:id" element={<CollaboratorAthletePage />} />
+              <Route path="results" element={<ResultsPage />} />
               <Route path="payments" element={<PaymentsPage />} />
             </Route>
 

--- a/src/web/pages/collaborator/AthletePage.tsx
+++ b/src/web/pages/collaborator/AthletePage.tsx
@@ -431,16 +431,12 @@ export default function AthletePage() {
                   athlete={athlete}
                   edition={athlete.edition}
                   isStaff={!!isStaff}
-                  isCommittee={!!isCommittee}
                   onParticipationChange={(appId, status) =>
                     mutations.participationMutation.mutate({ appId, status })
                   }
                   onRescore={(appId) => mutations.scoreMutation.mutate(appId)}
                   onWaPerfSave={(athleteId, eventId, data) =>
                     mutations.waPerfMutation.mutate({ athleteId, eventId, ...data })
-                  }
-                  onPlacementSave={(appId, placement) =>
-                    mutations.placementMutation.mutate({ appId, placement })
                   }
                   isPendingParticipation={mutations.participationMutation.isPending}
                   t={t}

--- a/src/web/pages/collaborator/athlete/BannerEventRow.tsx
+++ b/src/web/pages/collaborator/athlete/BannerEventRow.tsx
@@ -140,16 +140,14 @@ function sbColorClass(sb: number | null, app: ApplicationForAthlete, athlete: At
 
 // ── BannerEventRow ──────────────────────────────────────────────────────────
 
-export function BannerEventRow({ app, athlete, edition, isStaff, isCommittee, onParticipationChange, onRescore, onWaPerfSave, onPlacementSave, isPendingParticipation, t }: {
+export function BannerEventRow({ app, athlete, edition, isStaff, onParticipationChange, onRescore, onWaPerfSave, isPendingParticipation, t }: {
   app: ApplicationForAthlete
   athlete: AthleteDetail
   edition: EditionCosts | null
   isStaff: boolean
-  isCommittee?: boolean
   onParticipationChange: (appId: string, status: string) => void
   onRescore: (appId: string) => void
   onWaPerfSave: (athleteId: string, eventId: string, data: { personalBest?: number; seasonBest?: number; worldRanking?: number }) => void
-  onPlacementSave?: (appId: string, placement: number | null) => void
   isPendingParticipation: boolean
   t: (key: string) => string
 }) {
@@ -157,8 +155,6 @@ export function BannerEventRow({ app, athlete, edition, isStaff, isCommittee, on
   const [showEventPopup, setShowEventPopup] = useState(false)
   const [showScorePopup, setShowScorePopup] = useState(false)
   const [editingPerf, setEditingPerf] = useState(false)
-  const [editingPlacement, setEditingPlacement] = useState(false)
-  const [placementDraft, setPlacementDraft] = useState(app.finalPlacement != null ? String(app.finalPlacement) : '')
   const [perfForm, setPerfForm] = useState({
     personalBest: app.waPerformance?.personalBest != null
       ? String(isField ? app.waPerformance.personalBest / 100 : app.waPerformance.personalBest)
@@ -283,47 +279,6 @@ export function BannerEventRow({ app, athlete, edition, isStaff, isCommittee, on
           </>
         )}
       </div>
-
-      {/* Final placement — committee only, shown for confirmed athletes */}
-      {isCommittee && athlete.negotiationStatus === 'confirmed' && (
-        <div className="flex items-center gap-1 shrink-0">
-          {editingPlacement ? (
-            <>
-              <input
-                type="number"
-                min="1"
-                placeholder="#"
-                className="w-12 px-1 py-0.5 border border-gray-300 rounded text-xs"
-                value={placementDraft}
-                onChange={e => setPlacementDraft(e.target.value)}
-                autoFocus
-              />
-              <button
-                onClick={() => {
-                  const val = placementDraft.trim()
-                  const placement = val ? parseInt(val) : null
-                  onPlacementSave?.(app.id, placement)
-                  setEditingPlacement(false)
-                }}
-                className="text-[10px] text-green-600 hover:text-green-800"
-              >✓</button>
-              <button onClick={() => setEditingPlacement(false)} className="text-[10px] text-gray-400 hover:text-gray-600">✕</button>
-            </>
-          ) : (
-            <button
-              onClick={() => { setPlacementDraft(app.finalPlacement != null ? String(app.finalPlacement) : ''); setEditingPlacement(true) }}
-              className={`text-[10px] px-1.5 py-0.5 rounded border ${
-                app.finalPlacement != null
-                  ? 'bg-blue-50 border-blue-200 text-blue-700 font-medium'
-                  : 'border-dashed border-gray-300 text-gray-400 hover:border-gray-400'
-              }`}
-              title={t('payments.placement')}
-            >
-              {app.finalPlacement != null ? `#${app.finalPlacement}` : t('payments.noPlacement')}
-            </button>
-          )}
-        </div>
-      )}
 
       {/* Staff-only: edit perf + rescore */}
       {isStaff && !editingPerf && (

--- a/src/web/pages/collaborator/athlete/useAthleteData.ts
+++ b/src/web/pages/collaborator/athlete/useAthleteData.ts
@@ -120,12 +120,6 @@ export function useAthleteMutations(id: string | undefined) {
     ),
   })
 
-  const placementMutation = useMutation({
-    mutationFn: ({ appId, placement }: { appId: string; placement: number | null }) =>
-      api.patch(`/api/v1/applications/${appId}/final-placement`, { finalPlacement: placement }),
-    onSuccess: invalidate,
-  })
-
   return {
     statusMutation,
     agreementMutation,
@@ -139,7 +133,6 @@ export function useAthleteMutations(id: string | undefined) {
     counterOfferMutation,
     freeMessageMutation,
     archiveMutation,
-    placementMutation,
   }
 }
 

--- a/src/web/pages/committee/ResultsPage.tsx
+++ b/src/web/pages/committee/ResultsPage.tsx
@@ -1,0 +1,203 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import { api } from '@web/lib/api'
+import type { ResultAthleteEntry, ResultEventEntry, ResultsResponse } from '@shared/types'
+
+function AthleteRow({ ath, event, currency, onSave }: {
+  ath: ResultAthleteEntry
+  event: ResultEventEntry
+  currency: string
+  onSave: (appId: string, placement: number | null) => Promise<void>
+}) {
+  const [draft, setDraft] = useState(ath.finalPlacement != null ? String(ath.finalPlacement) : '')
+  const [saving, setSaving] = useState(false)
+
+  const computePrizeMoney = (placement: number | null): number => {
+    if (!placement || placement < 1 || placement > 8) return 0
+    const slot = event.prizeSlots.find(s => s.place === placement)
+    return slot?.amount ?? 0
+  }
+
+  const currentPlacement = draft.trim() ? parseInt(draft) : null
+  const previewPrizeMoney = computePrizeMoney(currentPlacement)
+
+  const handleBlur = async () => {
+    const val = draft.trim()
+    const placement = val ? parseInt(val) : null
+    if (placement === ath.finalPlacement) return
+    setSaving(true)
+    try {
+      await onSave(ath.applicationId, placement)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <tr className="border-b hover:bg-gray-50">
+      <td className="px-4 py-2.5">
+        <Link
+          to={`/committee/athletes/${ath.athleteId}`}
+          className="font-medium text-blue-600 hover:underline text-sm"
+          tabIndex={-1}
+        >
+          {ath.athleteLastName}, {ath.athleteFirstName}
+        </Link>
+      </td>
+      <td className="px-4 py-2.5 text-center w-32">
+        <input
+          type="number"
+          min="1"
+          placeholder="—"
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          onBlur={handleBlur}
+          disabled={saving}
+          className={`w-16 text-center px-2 py-1 border rounded text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-50 ${
+            ath.finalPlacement != null
+              ? 'border-blue-300 bg-blue-50 text-blue-800'
+              : 'border-gray-200 bg-white text-gray-700'
+          }`}
+        />
+      </td>
+      <td className="px-4 py-2.5 text-right font-mono text-sm w-40">
+        {previewPrizeMoney > 0 ? (
+          <span className={draft.trim() ? 'text-green-700 font-medium' : 'text-gray-400'}>
+            {currency} {previewPrizeMoney.toLocaleString()}
+          </span>
+        ) : (
+          <span className="text-gray-300">—</span>
+        )}
+      </td>
+    </tr>
+  )
+}
+
+export default function ResultsPage() {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+
+  const { data, isLoading } = useQuery<ResultsResponse>({
+    queryKey: ['results'],
+    queryFn: () => api.get('/api/v1/results'),
+  })
+
+  const [activeEventId, setActiveEventId] = useState<string | null>(null)
+
+  const placementMutation = useMutation({
+    mutationFn: ({ appId, placement }: { appId: string; placement: number | null }) =>
+      api.patch(`/api/v1/applications/${appId}/final-placement`, { finalPlacement: placement }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['results'] })
+    },
+  })
+
+  if (isLoading) {
+    return <div className="max-w-7xl mx-auto px-6 py-8 text-gray-400 text-sm">{t('common.loading')}</div>
+  }
+
+  const events = data?.events ?? []
+  const currency = data?.currency ?? 'CHF'
+
+  if (events.length === 0) {
+    return (
+      <div className="max-w-7xl mx-auto px-6 py-8">
+        <h1 className="text-xl font-bold mb-2">{t('results.title')}</h1>
+        <p className="text-gray-400 text-sm">{t('results.noEvents')}</p>
+      </div>
+    )
+  }
+
+  const currentEventId = activeEventId ?? events[0]?.eventId
+  const currentEvent = events.find(e => e.eventId === currentEventId)
+
+  return (
+    <div className="max-w-7xl mx-auto px-6 py-6">
+      <div className="mb-6">
+        <h1 className="text-xl font-bold">{t('results.title')}</h1>
+        <p className="text-sm text-gray-400 mt-0.5">{t('results.subtitle')}</p>
+      </div>
+
+      {/* Event tabs */}
+      <div className="flex flex-wrap gap-2 mb-5">
+        {events.map(ev => {
+          const placed = ev.athletes.filter(a => a.finalPlacement != null).length
+          const total = ev.athletes.length
+          const isActive = ev.eventId === currentEventId
+          return (
+            <button
+              key={ev.eventId}
+              onClick={() => setActiveEventId(ev.eventId)}
+              className={`px-3 py-1.5 text-sm rounded-md border flex items-center gap-2 transition-colors ${
+                isActive
+                  ? 'bg-gray-900 text-white border-gray-900 font-medium'
+                  : 'text-gray-600 border-gray-200 hover:bg-gray-50'
+              }`}
+            >
+              {ev.eventName}
+              <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${
+                isActive
+                  ? 'bg-white/20 text-white'
+                  : placed === total && total > 0
+                  ? 'bg-green-100 text-green-700'
+                  : placed > 0
+                  ? 'bg-amber-100 text-amber-700'
+                  : 'bg-gray-100 text-gray-500'
+              }`}>
+                {placed}/{total}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      {currentEvent && (
+        <>
+          {/* Prize money legend */}
+          {currentEvent.prizeSlots.length > 0 && (
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mb-4 text-xs text-gray-500">
+              <span className="font-medium text-gray-700">{t('results.prizeMoneyLegend')}:</span>
+              {currentEvent.prizeSlots.map(slot => (
+                <span key={slot.place} className="text-gray-500">
+                  {t('results.place')} {slot.place} — {currency} {slot.amount.toLocaleString()}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Athletes table */}
+          {currentEvent.athletes.length === 0 ? (
+            <p className="text-gray-400 text-sm">{t('results.noAthletes')}</p>
+          ) : (
+            <div className="bg-white rounded-lg border overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-gray-50 text-xs text-gray-500">
+                    <th className="px-4 py-2.5 text-left font-medium">{t('results.athlete')}</th>
+                    <th className="px-4 py-2.5 text-center font-medium w-32">{t('results.placement')}</th>
+                    <th className="px-4 py-2.5 text-right font-medium w-40">{t('results.prizeMoney')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {currentEvent.athletes.map(ath => (
+                    <AthleteRow
+                      key={ath.applicationId}
+                      ath={ath}
+                      event={currentEvent}
+                      currency={currency}
+                      onSave={async (appId, placement) => {
+                        await placementMutation.mutateAsync({ appId, placement })
+                      }}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Implements a dedicated Results page for entering final placements after the meeting, grouped by event.

## Changes
- New `/committee/results` page: event tabs with N/M badge, per-event athlete table, numeric inputs, auto-save on blur, real-time prize money preview
- New `GET /api/v1/results` backend route
- Removed inline placement editing from the athlete banner (BannerEventRow)
- Added shared types: ResultAthleteEntry, ResultEventEntry, ResultsResponse

Closes #100

Generated with [Claude Code](https://claude.ai/code)