### PR TITLE
feat: Afficher le nom de l'hôtel dans le bloc "Occupation hôtelière"

### DIFF
--- a/src/api/routes/dashboard.ts
+++ b/src/api/routes/dashboard.ts
@@ -28,6 +28,7 @@ dashboard.get('/', async (c) => {
   const agreements = await db.select().from(schema.agreement)
   const collaborators = await db.select().from(schema.user).where(eq(schema.user.role, 'collaborator'))
   const hotelRooms = await db.select().from(schema.hotelRoom)
+  const hotels = await db.select().from(schema.hotel)
 
   // Build catalog lookup
   const catalogMap = new Map(catalogRows.map(c => [c.id, c]))
@@ -138,12 +139,15 @@ dashboard.get('/', async (c) => {
     }
   }
 
+  const hotelMap = new Map(hotels.map(h => [h.id, h.name]))
+
   const hotelRoomStats = hotelRooms.map(room => {
     const confirmedCount = roomConfirmed.get(room.id) ?? 0
     const inNegCount = roomInNeg.get(room.id) ?? 0
     return {
       roomId: room.id,
       hotelId: room.hotelId,
+      hotelName: hotelMap.get(room.hotelId) ?? '',
       roomType: room.roomType,
       reservedRooms: room.reservedRooms,
       confirmedOccupancy: room.reservedRooms > 0 ? confirmedCount / room.reservedRooms : 0,

--- a/src/web/pages/committee/DashboardPage.tsx
+++ b/src/web/pages/committee/DashboardPage.tsx
@@ -22,6 +22,7 @@ interface EventStat {
 interface HotelRoomStat {
   roomId: string
   hotelId: string
+  hotelName: string
   roomType: string
   reservedRooms: number
   confirmedOccupancy: number
@@ -243,6 +244,7 @@ export default function DashboardPage() {
                 <div className="space-y-2">
                   {hotelRooms.map((room) => (
                     <div key={room.roomId} className="text-xs">
+                      <p className="text-gray-400 mb-0.5">{room.hotelName}</p>
                       <div className="flex justify-between mb-1">
                         <span className="font-medium">{room.roomType}</span>
                         <span className="font-mono">{room.confirmedCount}/{room.reservedRooms}</span>


### PR DESCRIPTION
Fixes #105

Ajoute le nom de l'hôtel dans le bloc "Occupation hôtelière" du tableau de bord comité.

**Changements :**
- Backend : le nom de l'hôtel est maintenant inclus dans les stats retournées par `/api/v1/dashboard`
- Frontend : affichage du nom de l'hôtel en gris au-dessus du type de chambre

Generated with [Claude Code](https://claude.ai/code)